### PR TITLE
[Feature/19] 애플 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,11 +59,21 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //openfeign
+    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.0")
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    //json
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+
+
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
 
 clean {
     delete file('src/main/generated')

--- a/src/main/java/com/example/namo2/Namo2Application.java
+++ b/src/main/java/com/example/namo2/Namo2Application.java
@@ -2,10 +2,12 @@ package com.example.namo2;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class Namo2Application {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/namo2/Namo2Application.java
+++ b/src/main/java/com/example/namo2/Namo2Application.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableFeignClients
 public class Namo2Application {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/namo2/domain/user/application/UserFacade.java
+++ b/src/main/java/com/example/namo2/domain/user/application/UserFacade.java
@@ -41,6 +41,7 @@ import com.example.namo2.global.utils.JwtUtils;
 import com.example.namo2.global.utils.SocialUtils;
 import com.example.namo2.global.utils.apple.AppleAuthClient;
 import com.example.namo2.global.utils.apple.AppleResponse;
+import com.example.namo2.global.utils.apple.AppleResponseConverter;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -55,6 +56,7 @@ public class UserFacade {
 	private final JwtUtils jwtUtils;
 	private final AppleAuthClient appleAuthClient;
 	private final RedisTemplate<String, String> redisTemplate;
+
 	private final UserService userService;
 	private final PaletteService paletteService;
 	private final CategoryService categoryService;
@@ -108,7 +110,6 @@ public class UserFacade {
 		AppleResponse.ApplePublicKeyDto applePublicKey = null;
 
 		try {
-
 			JSONParser parser = new JSONParser();
 			String[] decodeArr = req.getIdentityToken().split("\\.");
 			String header = new String(Base64.getDecoder().decode(decodeArr[0]));
@@ -118,11 +119,7 @@ public class UserFacade {
 			Object alg = headerJson.get("alg"); //토큰을 암호화하는데 사용되는 암호화 알고리즘
 
 			//identityToken 검증
-			applePublicKey =
-				applePublicKeys.getKeys().stream()
-					.filter(key -> key.getAlg().equals(alg) && key.getKid().equals(kid))
-					.findFirst()
-					.orElseThrow(() -> new BaseException(APPLE_REQUEST_ERROR));
+			applePublicKey = AppleResponseConverter.toApplePublicKey(applePublicKeys, kid, alg);
 		} catch (ParseException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/com/example/namo2/domain/user/application/UserFacade.java
+++ b/src/main/java/com/example/namo2/domain/user/application/UserFacade.java
@@ -29,7 +29,6 @@ import com.example.namo2.domain.category.application.converter.CategoryConverter
 import com.example.namo2.domain.category.application.impl.CategoryService;
 import com.example.namo2.domain.category.application.impl.PaletteService;
 import com.example.namo2.domain.category.domain.Category;
-import com.example.namo2.global.utils.apple.AppleAuthApi;
 import com.example.namo2.domain.user.application.converter.UserConverter;
 import com.example.namo2.domain.user.application.impl.UserService;
 import com.example.namo2.domain.user.domain.User;

--- a/src/main/java/com/example/namo2/domain/user/application/converter/UserConverter.java
+++ b/src/main/java/com/example/namo2/domain/user/application/converter/UserConverter.java
@@ -18,4 +18,11 @@ public class UserConverter {
 				.build();
 	}
 
+	public static User toUser(String email, String name){
+		return User.builder()
+			.email(email)
+			.name(name)
+			.build();
+	}
+
 }

--- a/src/main/java/com/example/namo2/domain/user/ui/AuthController.java
+++ b/src/main/java/com/example/namo2/domain/user/ui/AuthController.java
@@ -41,6 +41,15 @@ public class AuthController {
         return new BaseResponse<>(signupDto);
     }
 
+    @Operation(summary = "apple 회원가입", description = "apple 소셜 로그인을 통한 회원가입.")
+    @PostMapping(value = "/apple/signup")
+    public BaseResponse<UserResponse.SignUpDto> appleSignup(
+        @Valid @RequestBody UserRequest.AppleSignUpDto dto
+    ){
+        UserResponse.SignUpDto signupDto = userFacade.signupApple(dto);
+        return new BaseResponse<>(signupDto);
+    }
+
     @Operation(summary = "토큰 재발급", description = "토큰 재발급")
     @PostMapping(value = "/reissuance")
     public BaseResponse<UserResponse.SignUpDto> reissueAccessToken(

--- a/src/main/java/com/example/namo2/domain/user/ui/dto/UserRequest.java
+++ b/src/main/java/com/example/namo2/domain/user/ui/dto/UserRequest.java
@@ -35,4 +35,13 @@ public class UserRequest {
 		@NotBlank
 		private String accessToken;
 	}
+
+	@Getter
+	public static class AppleSignUpDto{
+		@NotBlank
+		private String identityToken;
+		private String email;
+		private String username;
+	}
+
 }

--- a/src/main/java/com/example/namo2/global/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/example/namo2/global/common/response/BaseResponseStatus.java
@@ -1,5 +1,7 @@
 package com.example.namo2.global.common.response;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 
 @Getter
@@ -11,19 +13,25 @@ public enum BaseResponseStatus {
     SUCCESS(200, "요청 성공"),
 
     /**
+     * 400 : Bad Request
+     */
+    MAKE_PUBLIC_KEY_FAILURE(400, "애플 퍼블릭 키를 생성하는데 실패하였습니다"),
+    //애플 identityToken 오류
+    APPLE_REQUEST_ERROR(400, "애플 identityToken이 잘못되었습니다."),
+
+    /**
      * 401 : 소셜 로그인 오류
      */
-
     SOCIAL_LOGIN_FAILURE(401, "소셜 로그인에 실패하였습니다."),
 
     /**
      * 403 : local Access Token 오류
      */
-
     EMPTY_ACCESS_KEY(403, "AccessToken 이 비어있습니다."),
     LOGOUT_ERROR(403, "로그 아웃된 사용자입니다."),
     EXPIRATION_ACCESS_TOKEN(403, "Access token 이 만료되었습니다."),
     EXPIRATION_REFRESH_TOKEN(403, "RefreshToken 이 만료되었습니다."),
+
 
     /**
      * NOT FOUND 오류

--- a/src/main/java/com/example/namo2/global/config/properties/FeignConfig.java
+++ b/src/main/java/com/example/namo2/global/config/properties/FeignConfig.java
@@ -1,0 +1,9 @@
+package com.example.namo2.global.config.properties;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients("com.example.namo2.global.utils.apple")
+public class FeignConfig {
+}

--- a/src/main/java/com/example/namo2/global/utils/apple/AppleAuthApi.java
+++ b/src/main/java/com/example/namo2/global/utils/apple/AppleAuthApi.java
@@ -1,0 +1,14 @@
+package com.example.namo2.global.utils.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(
+	name = "apple-public-key-client",
+	url = "https://appleid.apple.com/auth",
+	configuration = AppleFeignConfiguration.class
+)
+public interface AppleAuthApi {
+	@GetMapping(value = "/keys", consumes = "application/x-www-form-urlencoded")
+	AppleResponse.ApplePublicKeyListDto getApplePublicKeys();
+}

--- a/src/main/java/com/example/namo2/global/utils/apple/AppleAuthClient.java
+++ b/src/main/java/com/example/namo2/global/utils/apple/AppleAuthClient.java
@@ -1,14 +1,15 @@
 package com.example.namo2.global.utils.apple;
 
-import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.stereotype.Component;
 
-@FeignClient(
-	name = "apple-public-key-client",
-	url = "https://appleid.apple.com/auth",
-	configuration = AppleFeignConfiguration.class
-)
-public interface AppleAuthClient {
-	@GetMapping(value = "/keys", consumes = "application/x-www-form-urlencoded")
-	AppleResponse.ApplePublicKeyListDto getApplePublicKeys();
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AppleAuthClient {
+	private final AppleAuthClient appleAuthClient;
+
+	public AppleResponse.ApplePublicKeyListDto getApplePublicKeys(){
+		return appleAuthClient.getApplePublicKeys();
+	}
 }

--- a/src/main/java/com/example/namo2/global/utils/apple/AppleAuthClient.java
+++ b/src/main/java/com/example/namo2/global/utils/apple/AppleAuthClient.java
@@ -1,0 +1,14 @@
+package com.example.namo2.global.utils.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(
+	name = "apple-public-key-client",
+	url = "https://appleid.apple.com/auth",
+	configuration = AppleFeignConfiguration.class
+)
+public interface AppleAuthClient {
+	@GetMapping(value = "/keys", consumes = "application/x-www-form-urlencoded")
+	AppleResponse.ApplePublicKeyListDto getApplePublicKeys();
+}

--- a/src/main/java/com/example/namo2/global/utils/apple/AppleFeignConfiguration.java
+++ b/src/main/java/com/example/namo2/global/utils/apple/AppleFeignConfiguration.java
@@ -1,0 +1,12 @@
+package com.example.namo2.global.utils.apple;
+
+import org.springframework.context.annotation.Bean;
+
+import feign.Logger;
+
+public class AppleFeignConfiguration {
+	@Bean
+	Logger.Level feignLoggerLevel(){
+		return Logger.Level.FULL;
+	}
+}

--- a/src/main/java/com/example/namo2/global/utils/apple/AppleResponse.java
+++ b/src/main/java/com/example/namo2/global/utils/apple/AppleResponse.java
@@ -1,0 +1,30 @@
+package com.example.namo2.global.utils.apple;
+
+import java.util.List;
+
+import com.example.namo2.global.common.exception.BaseException;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class AppleResponse {
+	public AppleResponse(){
+		throw new IllegalStateException("Utility class");
+	}
+	@Getter
+	@Setter
+	public static class ApplePublicKeyDto {
+		private String kty;
+		private String kid;
+		private String use;
+		private String alg;
+		private String n;
+		private String e;
+	}
+
+	@Getter
+	@Setter
+	public static class ApplePublicKeyListDto {
+		private List<ApplePublicKeyDto> keys;
+	}
+}

--- a/src/main/java/com/example/namo2/global/utils/apple/AppleResponseConverter.java
+++ b/src/main/java/com/example/namo2/global/utils/apple/AppleResponseConverter.java
@@ -1,0 +1,21 @@
+package com.example.namo2.global.utils.apple;
+
+import static com.example.namo2.global.common.response.BaseResponseStatus.*;
+
+import com.example.namo2.global.common.exception.BaseException;
+
+public class AppleResponseConverter {
+	public AppleResponseConverter(){
+		throw new IllegalStateException("Utility class.");
+	}
+	public static AppleResponse.ApplePublicKeyDto toApplePublicKey(
+		AppleResponse.ApplePublicKeyListDto applePublicKeys,
+		Object alg,
+		Object kid
+	){
+		return applePublicKeys.getKeys().stream()
+			.filter(key -> key.getAlg().equals(alg) && key.getKid().equals(kid))
+			.findFirst()
+			.orElseThrow(() -> new BaseException(APPLE_REQUEST_ERROR));
+	}
+}

--- a/src/main/resources/application-auth.yml
+++ b/src/main/resources/application-auth.yml
@@ -20,6 +20,8 @@ spring:
             client-authentication-method: POST
             authorization-grant-type: authorization_code
             scope: profile_nickname, account_email #동의 항목
+          apple:
+            client-id: ${APPLE_CLIENT_ID}
 
 client-name:
   provider:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,3 +20,4 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
+    com.example.namo2: debug

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,4 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
     org.springframework.jdbc.datasource: DEBUG
+    com.example.namo2: debug

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,4 @@ logging:
   level:
     org.hibernate.SQL: info
     org.hibernate.type: trace
+    com.example.namo2: debug


### PR DESCRIPTION
## PR Desciption

> 변경 사항 설명
- UserFacade
  - AppleAuthClient를 통해 애플 public key 가져오기
  - req로 받아온 identityToken값을 애플 public key 로 검증 후 user등록
  - accessToken과 refreshToken 발급

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

~~- 애플에서 직접 identityToken을 발급 받을 수 있는 방법이 없어서 무조건 프론트를 통해서 테스트해야합니다! 그래서 제대로 작동하는지 테스트는 못해봤습니다 😭~~

- 프론트에서 애플 서버와 첫 통신할 때 cope설정을 통해 username과 email을 가져올 수 있어서 애플 소셜로그인 request로 username과 email을 받고 있습니다
  - 애플과 첫 통신 때를 제외하면 username을 가져올 수 있는 방법이 없어서 이렇게 구성했는데 괜찮을까요?

-  애플에서 제공하는 유저를 식별할 수 있는 키 (oauthId)를 활용할 곳이 있는지 궁금합니다!

- 사용자가 애플 로그인을 통해 이메일을 제공할 때 이메일 가리기를 선택할 수 있습니다. 그럼 한 유저가 실제 이메일과 XXXXXXX@privaterelay.appleid.com 형식의 가려진 이메일 2개를 가지게 되는 상황이 생길 것 같기도 한데, 만약 그렇다면 문제는 없을지 궁금합니다.
  - 위 상황이 발생한다면 처음 유저 등록시 이메일로 기존회원인지 검증하는 방식이 괜찮은 건지도 궁금합니다

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

- 참고 : https://github.com/Team-Shaka/Briefing-Backend/tree/develop

## 관련 이슈

- close #19 
