### PR TITLE
[Feature/36] 스케줄 삭제 api 오류 수정

### DIFF
--- a/src/main/java/com/example/namo2/domain/schedule/application/ScheduleFacade.java
+++ b/src/main/java/com/example/namo2/domain/schedule/application/ScheduleFacade.java
@@ -182,7 +182,7 @@ public class ScheduleFacade {
 			return;
 		}
 		User user = userService.getUser(userId);
-		MoimSchedule moimSchedule = moimScheduleService.getMoimScheduleWithMoimMemo(scheduleId);
+		MoimSchedule moimSchedule = moimScheduleService.getMoimSchedule(scheduleId);
 		MoimScheduleAndUser moimScheduleAndUser = moimScheduleAndUserService.getMoimScheduleAndUser(moimSchedule, user);
 
 		// 마지막 사람이면 모임 스케줄 삭제

--- a/src/main/java/com/example/namo2/domain/schedule/application/ScheduleFacade.java
+++ b/src/main/java/com/example/namo2/domain/schedule/application/ScheduleFacade.java
@@ -185,34 +185,7 @@ public class ScheduleFacade {
 		MoimSchedule moimSchedule = moimScheduleService.getMoimSchedule(scheduleId);
 		MoimScheduleAndUser moimScheduleAndUser = moimScheduleAndUserService.getMoimScheduleAndUser(moimSchedule, user);
 
-		// 마지막 사람이면 모임 스케줄 삭제
-		if (moimSchedule.isLastScheduleMember()) {
-			moimScheduleAndUserService.removeMoimScheduleAndUser(moimScheduleAndUser);
-			MoimMemo moimMemo = moimSchedule.getMoimMemo();
-			removeMoimScheduleMemo(moimMemo);
-			moimScheduleService.remove(moimSchedule);
-			return;
-		}
 		moimScheduleAndUserService.removeMoimScheduleAndUser(moimScheduleAndUser);
 	}
 
-	private void removeMoimScheduleMemo(MoimMemo moimMemo) {
-		if (moimMemo == null) {
-			return;
-		}
-		List<MoimMemoLocation> moimMemoLocations = moimMemoLocationService.getMoimMemoLocation(moimMemo);
-		moimMemoLocationService.removeMoimMemoLocationAndUsers(moimMemoLocations);
-		removeMoimMemoLocationImgs(moimMemoLocations);
-		moimMemoService.removeMoimMemo(moimMemo);
-	}
-
-	private void removeMoimMemoLocationImgs(List<MoimMemoLocation> moimMemoLocations) {
-		List<MoimMemoLocationImg> moimMemoLocationImgs
-			= moimMemoLocationService.getMoimMemoLocationImgs(moimMemoLocations);
-		List<String> urls = moimMemoLocationImgs.stream()
-			.map(MoimMemoLocationImg::getUrl)
-			.collect(Collectors.toList());
-		fileUtils.deleteImages(urls);
-		moimMemoLocationService.removeMoimMemoLocationImgs(moimMemoLocations);
-	}
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 스케줄 삭제 api에서 모임 스케줄 삭제시 모임 스케줄을 찾지 못함.
  - 모임 스케줄을 가져올 때 함수를 getMoimScheduleWithMoimMemo()로 잘못 사용하고 있어서 getMoimSchedule()로 변경 
- 마지막 사람일때 모임 스케줄 삭제 로직 -> delete
  - 개인쪽에서 모임스케줄을 삭제할때는 모임 스케줄 자체가 삭제되지 않음

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #36 