### PR TITLE
[Feature/38] 모임 일정 전체 조회 API 추가

### DIFF
--- a/src/main/java/com/example/namo2/domain/moim/application/MoimFacade.java
+++ b/src/main/java/com/example/namo2/domain/moim/application/MoimFacade.java
@@ -27,6 +27,11 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class MoimFacade {
+	/**
+	 * TODO
+	 * ISSUE 설명: Moim_USER_COLOR 에 대한 부여를 현재 총 모임원의 index를 통해서 부여함
+	 * 이 경우 모임원이 탈퇴하고 다시금 들어올 경우 동일한 color를 부여받는 모임원이 생김
+	 */
 	private static final int[] MOIM_USERS_COLOR = new int[] {5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
 	private final MoimService moimService;
 	private final UserService userService;

--- a/src/main/java/com/example/namo2/domain/moim/application/MoimScheduleFacade.java
+++ b/src/main/java/com/example/namo2/domain/moim/application/MoimScheduleFacade.java
@@ -170,7 +170,7 @@ public class MoimScheduleFacade {
 	}
 
 	@Transactional(readOnly = true)
-	public List<MoimScheduleResponse.MoimScheduleDto> getMoimSchedules(Long moimId,
+	public List<MoimScheduleResponse.MoimScheduleDto> getMonthMoimSchedules(Long moimId,
 		List<LocalDateTime> localDateTimes) {
 		Moim moim = moimService.getMoim(moimId);
 		List<MoimAndUser> moimAndUsersInMoim = moimAndUserService.getMoimAndUsers(moim);
@@ -178,7 +178,20 @@ public class MoimScheduleFacade {
 
 		List<Schedule> indivisualsSchedules = scheduleService.getSchedules(users);
 		List<MoimScheduleAndUser> moimScheduleAndUsers = moimScheduleService
-			.getMoimSchedules(localDateTimes, users);
+			.getMonthMoimSchedules(localDateTimes, users);
+		return MoimScheduleResponseConverter
+			.toMoimScheduleDtos(indivisualsSchedules, moimScheduleAndUsers, moimAndUsersInMoim);
+	}
+
+	@Transactional(readOnly = true)
+	public List<MoimScheduleResponse.MoimScheduleDto> getAllMoimSchedules(Long moimId) {
+		Moim moim = moimService.getMoim(moimId);
+		List<MoimAndUser> moimAndUsersInMoim = moimAndUserService.getMoimAndUsers(moim);
+		List<User> users = MoimAndUserConverter.toUsers(moimAndUsersInMoim);
+
+		List<Schedule> indivisualsSchedules = scheduleService.getSchedules(users);
+		List<MoimScheduleAndUser> moimScheduleAndUsers = moimScheduleService
+			.getAllMoimSchedules(users);
 		return MoimScheduleResponseConverter
 			.toMoimScheduleDtos(indivisualsSchedules, moimScheduleAndUsers, moimAndUsersInMoim);
 	}

--- a/src/main/java/com/example/namo2/domain/moim/application/converter/MoimScheduleResponseConverter.java
+++ b/src/main/java/com/example/namo2/domain/moim/application/converter/MoimScheduleResponseConverter.java
@@ -32,18 +32,34 @@ public class MoimScheduleResponseConverter {
 		return result;
 	}
 
-	private static void addMoimSchedulesToResult(List<MoimAndUser> moimAndUsers,
-		List<MoimScheduleResponse.MoimScheduleDto> result,
-		Map<MoimSchedule, List<MoimScheduleResponse.MoimScheduleUserDto>> moimScheduleMappingUserDtoMap) {
-		for (MoimSchedule moimSchedule : moimScheduleMappingUserDtoMap.keySet()) {
-			MoimScheduleResponse.MoimScheduleDto moimScheduleDto = toMoimScheduleDto(moimSchedule);
-			moimScheduleDto.setUsers(
-				moimScheduleMappingUserDtoMap.get(moimSchedule),
-				moimSchedule.getMoim() == moimAndUsers.get(0).getMoim(),
-				moimSchedule.getMoimMemo() != null
-			);
-			result.add(moimScheduleDto);
-		}
+	private static List<MoimScheduleResponse.MoimScheduleDto> getMoimScheduleDtos(List<Schedule> indivisualsSchedules,
+		List<MoimAndUser> moimAndUsers) {
+		Map<User, Integer> usersColor = moimAndUsers.stream().collect(
+			Collectors.toMap(
+				MoimAndUser::getUser, MoimAndUser::getColor
+			));
+		List<MoimScheduleResponse.MoimScheduleDto> result = indivisualsSchedules.stream()
+			.map((schedule -> toMoimScheduleDto(schedule, usersColor.get(schedule.getUser()))))
+			.collect(Collectors.toList());
+		return result;
+	}
+
+	private static Map<User, MoimScheduleResponse.MoimScheduleUserDto> getMoimScheduleUserDtoMap(
+		List<MoimAndUser> moimAndUsers) {
+		return moimAndUsers.stream()
+			.collect(Collectors.toMap(
+				MoimAndUser::getUser,
+				(moimAndUser -> toMoimScheduleUserDto(moimAndUser))
+			));
+	}
+
+	private static MoimScheduleResponse.MoimScheduleUserDto toMoimScheduleUserDto(MoimAndUser moimAndUser) {
+		return MoimScheduleResponse.MoimScheduleUserDto
+			.builder()
+			.userId(moimAndUser.getUser().getId())
+			.userName(moimAndUser.getUser().getName())
+			.color(moimAndUser.getColor())
+			.build();
 	}
 
 	private static Map<MoimSchedule, List<MoimScheduleResponse.MoimScheduleUserDto>> getMoimScheduleMappingUserDtoMap(
@@ -60,25 +76,18 @@ public class MoimScheduleResponseConverter {
 		);
 	}
 
-	private static Map<User, MoimScheduleResponse.MoimScheduleUserDto> getMoimScheduleUserDtoMap(
-		List<MoimAndUser> moimAndUsers) {
-		return moimAndUsers.stream()
-			.collect(Collectors.toMap(
-				MoimAndUser::getUser,
-				(moimAndUser -> toMoimScheduleUserDto(moimAndUser))
-			));
-	}
-
-	private static List<MoimScheduleResponse.MoimScheduleDto> getMoimScheduleDtos(List<Schedule> indivisualsSchedules,
-		List<MoimAndUser> moimAndUsers) {
-		Map<User, Integer> usersColor = moimAndUsers.stream().collect(
-			Collectors.toMap(
-				MoimAndUser::getUser, MoimAndUser::getColor
-			));
-		List<MoimScheduleResponse.MoimScheduleDto> result = indivisualsSchedules.stream()
-			.map((schedule -> toMoimScheduleDto(schedule, usersColor.get(schedule.getUser()))))
-			.collect(Collectors.toList());
-		return result;
+	private static void addMoimSchedulesToResult(List<MoimAndUser> moimAndUsers,
+		List<MoimScheduleResponse.MoimScheduleDto> result,
+		Map<MoimSchedule, List<MoimScheduleResponse.MoimScheduleUserDto>> moimScheduleMappingUserDtoMap) {
+		for (MoimSchedule moimSchedule : moimScheduleMappingUserDtoMap.keySet()) {
+			MoimScheduleResponse.MoimScheduleDto moimScheduleDto = toMoimScheduleDto(moimSchedule);
+			moimScheduleDto.setUsers(
+				moimScheduleMappingUserDtoMap.get(moimSchedule),
+				moimSchedule.getMoim() == moimAndUsers.get(0).getMoim(),
+				moimSchedule.getMoimMemo() != null
+			);
+			result.add(moimScheduleDto);
+		}
 	}
 
 	public static MoimScheduleResponse.MoimScheduleDto toMoimScheduleDto(Schedule schedule, Integer color) {
@@ -105,15 +114,6 @@ public class MoimScheduleResponseConverter {
 			moimSchedule.getLocation().getY(),
 			moimSchedule.getLocation().getLocationName()
 		);
-	}
-
-	private static MoimScheduleResponse.MoimScheduleUserDto toMoimScheduleUserDto(MoimAndUser moimAndUser) {
-		return MoimScheduleResponse.MoimScheduleUserDto
-			.builder()
-			.userId(moimAndUser.getId())
-			.userName(moimAndUser.getUser().getName())
-			.color(moimAndUser.getColor())
-			.build();
 	}
 
 }

--- a/src/main/java/com/example/namo2/domain/moim/application/impl/MoimScheduleService.java
+++ b/src/main/java/com/example/namo2/domain/moim/application/impl/MoimScheduleService.java
@@ -25,6 +25,11 @@ public class MoimScheduleService {
 	private final MoimScheduleRepository moimScheduleRepository;
 	private final MoimScheduleAndUserRepository moimScheduleAndUserRepository;
 
+	/**
+	 * TODO: MoimSchedule 생성시 밸리데이션 처리
+	 * 자신이 모임에 소속된 사람이 아닐 시 모임에 대한 스케줄을 생성할 수 없게
+	 * 검증 처리가 있으면 좋을 듯합니다.
+	 */
 	public MoimSchedule create(MoimSchedule moimSchedule) {
 		return moimScheduleRepository.save(moimSchedule);
 	}
@@ -43,11 +48,18 @@ public class MoimScheduleService {
 		moimScheduleRepository.delete(moimSchedule);
 	}
 
-	public List<MoimScheduleAndUser> getMoimSchedules(
+	public List<MoimScheduleAndUser> getMonthMoimSchedules(
 		List<LocalDateTime> localDateTimes, List<User> users) {
 		return moimScheduleAndUserRepository
 			.findMoimScheduleAndUserWithMoimScheduleByUsersAndDates(
 				localDateTimes.get(0), localDateTimes.get(1), users
+			);
+	}
+
+	public List<MoimScheduleAndUser> getAllMoimSchedules(List<User> users) {
+		return moimScheduleAndUserRepository
+			.findMoimScheduleAndUserWithMoimScheduleByUsersAndDates(
+				null, null, users
 			);
 	}
 

--- a/src/main/java/com/example/namo2/domain/moim/dao/repository/MoimScheduleAndUserRepositoryImpl.java
+++ b/src/main/java/com/example/namo2/domain/moim/dao/repository/MoimScheduleAndUserRepositoryImpl.java
@@ -11,6 +11,7 @@ import jakarta.persistence.EntityManager;
 
 import org.springframework.data.domain.Pageable;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import com.example.namo2.domain.moim.domain.MoimScheduleAndUser;
@@ -32,17 +33,26 @@ public class MoimScheduleAndUserRepositoryImpl implements MoimScheduleAndUserRep
 			.join(moimScheduleAndUser.moimSchedule, moimSchedule).fetchJoin()
 			.join(moimScheduleAndUser.category, category).fetchJoin()
 			.leftJoin(moimSchedule.moimMemo).fetchJoin()
-			.where(moimScheduleAndUser.user.in(users)
-				.and(moimScheduleAndUser.moimSchedule.period.startDate.loe(endDate))
-				.and(moimScheduleAndUser.moimSchedule.period.endDate.goe(startDate))
-				.and(moimScheduleAndUser.category.share.isTrue()))
+			.where(moimScheduleAndUser.user.in(users),
+				moimScheduleDateGoe(startDate),
+				moimScheduleDateLoe(endDate),
+				moimScheduleAndUser.category.share.isTrue()
+			)
 			.fetch();
 	}
 
+	private BooleanExpression moimScheduleDateGoe(LocalDateTime startDate) {
+		return startDate != null ? moimSchedule.period.endDate.after(startDate) : null;
+	}
+
+	private BooleanExpression moimScheduleDateLoe(LocalDateTime endDate) {
+		return endDate != null ? moimSchedule.period.startDate.before(endDate) : null;
+	}
+
 	/**
-	 * @param 김현재 이 부분에 대해서는 MoimScheduleAndUser를 반환해서
-	 *            우선 MoimScheduleAndUserRepository로
-	 *            넘기기는 했는데 MoimMemo에 가까운 로직이라 이곳으로 들어오는게 맞나 싶네요?
+	 * 이 부분에 대해서는 MoimScheduleAndUser를 반환해서
+	 * 우선 MoimScheduleAndUserRepository로
+	 * 넘기기는 했는데 MoimMemo에 가까운 로직이라 이곳으로 들어오는게 맞나 싶네요?
 	 */
 	@Override
 	public List<MoimScheduleAndUser> findMoimScheduleMemoByMonthPaging(User user, List<LocalDateTime> dates,

--- a/src/main/java/com/example/namo2/domain/moim/ui/MoimScheduleController.java
+++ b/src/main/java/com/example/namo2/domain/moim/ui/MoimScheduleController.java
@@ -70,11 +70,19 @@ public class MoimScheduleController {
 
 	@Operation(summary = "월간 모임 스케쥴 조회", description = "월간 모임 스케쥴 조회 API")
 	@GetMapping("/{moimId}/{month}")
-	public BaseResponse<MoimScheduleResponse.MoimScheduleDto> getMoimSchedules(@PathVariable("moimId") Long moimId,
+	public BaseResponse<MoimScheduleResponse.MoimScheduleDto> getMonthMoimSchedules(@PathVariable("moimId") Long moimId,
 		@PathVariable("month") String month) {
 		List<LocalDateTime> localDateTimes = converter.convertLongToLocalDateTime(month);
-		List<MoimScheduleResponse.MoimScheduleDto> schedules = moimScheduleFacade.getMoimSchedules(moimId,
+		List<MoimScheduleResponse.MoimScheduleDto> schedules = moimScheduleFacade.getMonthMoimSchedules(moimId,
 			localDateTimes);
+		return new BaseResponse(schedules);
+	}
+
+	@Operation(summary = "모든 모임 스케쥴 조회", description = "모든 모임 스케쥴 조회 API")
+	@GetMapping("/{moimId}/all")
+	public BaseResponse<MoimScheduleResponse.MoimScheduleDto> getAllMoimSchedules(
+		@PathVariable("moimId") Long moimId) {
+		List<MoimScheduleResponse.MoimScheduleDto> schedules = moimScheduleFacade.getAllMoimSchedules(moimId);
 		return new BaseResponse(schedules);
 	}
 


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- MoimScheduleAndUserRepositoryImpl.java
  - querydsl 활용해서 기존 로직 재사용 가능하게 변경
- MoimScheduleResponseConverter.java
  - toMoimScheduleUserDto 메서드서 버그 발견 및 수정
- 대부분 월간 모음 스케줄 조회를 그대로 재활용하여 코드를 생성했습니다.

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 없음

### 고민 중인 사항

-  Moim_USER_COLOR 에 대한 부여를 현재 총 모임원의 총 수를 통해서 부여함
  - 이 경우 모임원이 탈퇴하고 다시금 들어올 경우 동일한 color를 부여받는 모임원이 생김
- 전체 모임 조회 시 다른 moimScheulde 에 대한 moimId를 노출하게 됨 
  - 모임에 소속되지 않은 유저가 모임 스케줄을 추가하는 경우에 대한 검증 처리가 필요할 듯함


## 첨부 자료
-

## 관련 이슈

- close #38
