### PR TITLE
[Feature/78] 모임일정에 kakaoLocationId 추가

### DIFF
--- a/src/main/java/com/example/namo2/domain/moim/application/converter/MoimScheduleConverter.java
+++ b/src/main/java/com/example/namo2/domain/moim/application/converter/MoimScheduleConverter.java
@@ -43,6 +43,7 @@ public class MoimScheduleConverter {
 			.x(moimScheduleDto.getX())
 			.y(moimScheduleDto.getY())
 			.locationName(moimScheduleDto.getLocationName())
+			.kakaoLocationId(moimScheduleDto.getKakaoLocationId())
 			.build();
 	}
 

--- a/src/main/java/com/example/namo2/domain/moim/application/converter/MoimScheduleResponseConverter.java
+++ b/src/main/java/com/example/namo2/domain/moim/application/converter/MoimScheduleResponseConverter.java
@@ -112,7 +112,8 @@ public class MoimScheduleResponseConverter {
 			moimSchedule.getId(),
 			moimSchedule.getLocation().getX(),
 			moimSchedule.getLocation().getY(),
-			moimSchedule.getLocation().getLocationName()
+			moimSchedule.getLocation().getLocationName(),
+			moimSchedule.getLocation().getKakaoLocationId()
 		);
 	}
 

--- a/src/main/java/com/example/namo2/domain/moim/ui/dto/MoimScheduleRequest.java
+++ b/src/main/java/com/example/namo2/domain/moim/ui/dto/MoimScheduleRequest.java
@@ -35,6 +35,7 @@ public class MoimScheduleRequest {
 		@SuppressWarnings("checkstyle:MemberName")
 		private Double y;
 		private String locationName;
+		private String kakaoLocationId;
 
 		@NotNull
 		private List<Long> users;
@@ -59,6 +60,7 @@ public class MoimScheduleRequest {
 		private Double x;
 		private Double y;
 		private String locationName;
+		private String kakaoLocationId;
 
 		@NotNull
 		private List<Long> users;

--- a/src/main/java/com/example/namo2/domain/moim/ui/dto/MoimScheduleResponse.java
+++ b/src/main/java/com/example/namo2/domain/moim/ui/dto/MoimScheduleResponse.java
@@ -34,12 +34,13 @@ public class MoimScheduleResponse {
 		private Double x;
 		private Double y;
 		private String locationName;
+		private String kakaoLocationId;
 		private boolean hasDiaryPlace;
 
 		@QueryProjection
 		@Builder
 		public MoimScheduleDto(String name, LocalDateTime startDate, LocalDateTime endDate, Integer interval,
-			Long moimId, Long moimScheduleId, Double x, Double y, String locationName) {
+			Long moimId, Long moimScheduleId, Double x, Double y, String locationName, String kakaoLocationId) {
 			this.name = name;
 			this.startDate = startDate.atZone(ZoneId.systemDefault())
 				.toInstant()
@@ -53,6 +54,7 @@ public class MoimScheduleResponse {
 			this.x = x;
 			this.y = y;
 			this.locationName = locationName;
+			this.kakaoLocationId = kakaoLocationId;
 		}
 
 		@QueryProjection

--- a/src/main/java/com/example/namo2/domain/schedule/application/ScheduleFacade.java
+++ b/src/main/java/com/example/namo2/domain/schedule/application/ScheduleFacade.java
@@ -153,7 +153,8 @@ public class ScheduleFacade {
 			category,
 			req.getX(),
 			req.getY(),
-			req.getLocationName()
+			req.getLocationName(),
+			req.getKakaoLocationId()
 		);
 
 		return ScheduleResponseConverter.toScheduleIdRes(schedule);

--- a/src/main/java/com/example/namo2/domain/schedule/domain/Location.java
+++ b/src/main/java/com/example/namo2/domain/schedule/domain/Location.java
@@ -14,16 +14,18 @@ public class Location {
 	private Double x;
 	private Double y;
 	private String locationName;
+	private String kakaoLocationId;
 
 	@Builder
-	public Location(Double x, Double y, String locationName) {
+	public Location(Double x, Double y, String locationName, String kakaoLocationId) {
 		this.x = x;
 		this.y = y;
 		this.locationName = locationName;
+		this.kakaoLocationId = kakaoLocationId;
 	}
 
-	public static Location create(Double x, Double y, String locationName) {
-		return new Location(x, y, locationName);
+	public static Location create(Double x, Double y, String locationName, String kakaoLocationId) {
+		return new Location(x, y, locationName, kakaoLocationId);
 	}
 
 }

--- a/src/main/java/com/example/namo2/domain/schedule/domain/Schedule.java
+++ b/src/main/java/com/example/namo2/domain/schedule/domain/Schedule.java
@@ -68,20 +68,21 @@ public class Schedule extends BaseTimeEntity {
 
 	@Builder
 	public Schedule(Long id, String name, Period period, User user, Category category, Double x, Double y,
-		String locationName, Integer eventId) {
+		String locationName, String kakaoLocationId, Integer eventId) {
 		this.id = id;
 		this.name = name;
 		this.period = period;
-		this.location = new Location(x, y, locationName);
+		this.location = new Location(x, y, locationName, kakaoLocationId);
 		this.user = user;
 		this.category = category;
 		hasDiary = false;
 	}
 
-	public void updateSchedule(String name, Period period, Category category, Double x, Double y, String locationName) {
+	public void updateSchedule(String name, Period period, Category category, Double x, Double y, String locationName,
+		String kakaoLocationId) {
 		this.name = name;
 		this.period = period;
-		this.location = new Location(x, y, locationName);
+		this.location = new Location(x, y, locationName, kakaoLocationId);
 		this.category = category;
 	}
 

--- a/src/main/java/com/example/namo2/domain/schedule/ui/dto/ScheduleRequest.java
+++ b/src/main/java/com/example/namo2/domain/schedule/ui/dto/ScheduleRequest.java
@@ -28,6 +28,7 @@ public class ScheduleRequest {
 		private Double x;
 		private Double y;
 		private String locationName;
+		private String kakaoLocationId;
 		@NotNull
 		private Long categoryId;
 	}


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가

## PR Desciption

> 변경 사항 설명

- MoimScheduleRequest.PostMoimScheduleDto에 kakaoLocationId 필드 추가
- MoimScheduleRequest.PatchMoimScheduleDto에 kakaoLocationId 필드 추가
- MoimScheduleResponse.MoimScheduleDto에 kakaoLocationId 필드 추가

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
![image](https://github.com/Namo-Mongmong/Server/assets/112065014/2232db79-9f36-4840-81f3-89d7ecc8a9a6)

-  원래 모든 모임 스케줄 조회에 개인 일정도 뜨는게 맞나요? 맞다면 프론트에서 개인일정 data는 사용하지 않는건지 궁금합니다. moimId부터 kakaoLocationId까지 값이 null로 나오는데 이게 제가 하다가 잘못한건지 원래 이런건지 모르겠어서 물어봅니다!

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #78 
