### PR TITLE
[feature/139] Uesr 도메인 모듈 분리

### DIFF
--- a/application/README.md
+++ b/application/README.md
@@ -34,4 +34,8 @@
 
 ## Update History
 
-- 2024.06.11: `application` 모듈 및 `external-api` 모듈 생성
+- 2024.06.11
+  - `application` 모듈 및 `external-api` 모듈 생성
+- 2024.06.18
+  - `jpa` 관련 설정 이관 (`db-mysql` 모듈로 이동)
+  - `user` 도메인 모듈 분리 (`entity`, `repository` 패키지 `db-mysql` 모듈로 이동)

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/test/controller/TestController.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/test/controller/TestController.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.test.ui;
+package com.namo.spring.application.external.api.test.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.namo.spring.application.external.domain.test.ui.dto.TestRequest;
-import com.namo.spring.application.external.domain.test.ui.dto.TestResponse;
+import com.namo.spring.application.external.api.test.dto.TestRequest;
+import com.namo.spring.application.external.api.test.dto.TestResponse;
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCode;
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
 import com.namo.spring.core.common.code.status.ErrorStatus;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/test/dto/TestRequest.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/test/dto/TestRequest.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.test.ui.dto;
+package com.namo.spring.application.external.api.test.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/test/dto/TestResponse.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/test/dto/TestResponse.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.test.ui.dto;
+package com.namo.spring.application.external.api.test.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/user/controller/AuthController.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/user/controller/AuthController.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.ui;
+package com.namo.spring.application.external.api.user.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -8,10 +8,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.namo.spring.application.external.domain.user.application.UserFacade;
+import com.namo.spring.application.external.api.user.dto.UserRequest;
+import com.namo.spring.application.external.api.user.dto.UserResponse;
+import com.namo.spring.application.external.api.user.facade.UserFacade;
 import com.namo.spring.db.mysql.domains.user.type.SocialType;
-import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
-import com.namo.spring.application.external.domain.user.ui.dto.UserResponse;
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.response.ResponseDto;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/user/controller/TermController.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/user/controller/TermController.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.ui;
+package com.namo.spring.application.external.api.user.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.namo.spring.application.external.domain.user.application.UserFacade;
-import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
+import com.namo.spring.application.external.api.user.dto.UserRequest;
+import com.namo.spring.application.external.api.user.facade.UserFacade;
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.response.ResponseDto;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/user/converter/TermConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/user/converter/TermConverter.java
@@ -1,14 +1,14 @@
-package com.namo.spring.application.external.domain.user.application.converter;
+package com.namo.spring.application.external.api.user.converter;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.namo.spring.application.external.api.user.dto.UserRequest;
+import com.namo.spring.application.external.api.user.dto.UserResponse;
 import com.namo.spring.db.mysql.domains.user.domain.Term;
 import com.namo.spring.db.mysql.domains.user.type.Content;
 import com.namo.spring.db.mysql.domains.user.domain.User;
-import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
-import com.namo.spring.application.external.domain.user.ui.dto.UserResponse;
 
 public class TermConverter {
 	public static List<Term> toTerms(UserRequest.TermDto termDto, User user) {

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/user/converter/UserConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/user/converter/UserConverter.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.application.converter;
+package com.namo.spring.application.external.api.user.converter;
 
 import java.util.Map;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/user/converter/UserResponseConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/user/converter/UserResponseConverter.java
@@ -1,8 +1,8 @@
-package com.namo.spring.application.external.domain.user.application.converter;
+package com.namo.spring.application.external.api.user.converter;
 
 import java.util.List;
 
-import com.namo.spring.application.external.domain.user.ui.dto.UserResponse;
+import com.namo.spring.application.external.api.user.dto.UserResponse;
 
 public class UserResponseConverter {
 	private UserResponseConverter() {

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/user/dto/UserRequest.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/user/dto/UserRequest.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.ui.dto;
+package com.namo.spring.application.external.api.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/user/dto/UserResponse.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/user/dto/UserResponse.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.ui.dto;
+package com.namo.spring.application.external.api.user.dto;
 
 import java.util.List;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/user/facade/UserFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/user/facade/UserFacade.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.application;
+package com.namo.spring.application.external.api.user.facade;
 
 import java.net.HttpURLConnection;
 import java.security.PublicKey;
@@ -21,6 +21,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.namo.spring.application.external.api.user.converter.UserConverter;
+import com.namo.spring.application.external.api.user.converter.UserResponseConverter;
+import com.namo.spring.application.external.api.user.service.UserService;
 import com.namo.spring.application.external.domain.group.application.impl.MoimAndUserService;
 import com.namo.spring.application.external.domain.group.application.impl.MoimMemoLocationService;
 import com.namo.spring.application.external.domain.group.application.impl.MoimScheduleAndUserService;
@@ -35,16 +38,13 @@ import com.namo.spring.application.external.domain.individual.domain.Category;
 import com.namo.spring.application.external.domain.individual.domain.Image;
 import com.namo.spring.application.external.domain.individual.domain.Schedule;
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryKind;
-import com.namo.spring.application.external.domain.user.application.converter.TermConverter;
-import com.namo.spring.application.external.domain.user.application.converter.UserConverter;
-import com.namo.spring.application.external.domain.user.application.converter.UserResponseConverter;
-import com.namo.spring.application.external.domain.user.application.impl.UserService;
+import com.namo.spring.application.external.api.user.converter.TermConverter;
 import com.namo.spring.db.mysql.domains.user.domain.Term;
 import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.db.mysql.domains.user.type.SocialType;
 import com.namo.spring.db.mysql.domains.user.type.UserStatus;
-import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
-import com.namo.spring.application.external.domain.user.ui.dto.UserResponse;
+import com.namo.spring.application.external.api.user.dto.UserRequest;
+import com.namo.spring.application.external.api.user.dto.UserResponse;
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.client.social.apple.client.AppleAuthClient;
 import com.namo.spring.client.social.common.properties.AppleProperties;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/user/service/UserService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/user/service/UserService.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.application.impl;
+package com.namo.spring.application.external.api.user.service;
 
 import java.math.BigInteger;
 import java.security.KeyFactory;
@@ -25,7 +25,7 @@ import com.namo.spring.db.mysql.domains.user.type.SocialType;
 import com.namo.spring.db.mysql.domains.user.type.UserStatus;
 import com.namo.spring.db.mysql.domains.user.repository.TermRepository;
 import com.namo.spring.db.mysql.domains.user.repository.UserRepository;
-import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
+import com.namo.spring.application.external.api.user.dto.UserRequest;
 import com.namo.spring.application.external.global.utils.JwtUtils;
 import com.namo.spring.client.social.common.properties.AppleProperties;
 import com.namo.spring.client.social.apple.dto.AppleResponse;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimFacade.java
@@ -20,7 +20,7 @@ import com.namo.spring.application.external.domain.group.domain.MoimAndUser;
 import com.namo.spring.application.external.domain.group.ui.dto.GroupRequest;
 import com.namo.spring.application.external.domain.group.ui.dto.GroupResponse;
 import com.namo.spring.application.external.domain.user.application.impl.UserService;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.application.external.global.utils.FileUtils;
 import com.namo.spring.core.common.code.status.ErrorStatus;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimFacade.java
@@ -19,7 +19,7 @@ import com.namo.spring.application.external.domain.group.domain.Moim;
 import com.namo.spring.application.external.domain.group.domain.MoimAndUser;
 import com.namo.spring.application.external.domain.group.ui.dto.GroupRequest;
 import com.namo.spring.application.external.domain.group.ui.dto.GroupResponse;
-import com.namo.spring.application.external.domain.user.application.impl.UserService;
+import com.namo.spring.application.external.api.user.service.UserService;
 import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.application.external.global.utils.FileUtils;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimMemoFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimMemoFacade.java
@@ -24,7 +24,7 @@ import com.namo.spring.application.external.domain.group.domain.MoimScheduleAndU
 import com.namo.spring.application.external.domain.group.ui.dto.GroupDiaryRequest;
 import com.namo.spring.application.external.domain.group.ui.dto.GroupDiaryResponse;
 import com.namo.spring.application.external.domain.group.ui.dto.GroupScheduleRequest;
-import com.namo.spring.application.external.domain.user.application.impl.UserService;
+import com.namo.spring.application.external.api.user.service.UserService;
 import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.application.external.global.utils.FileUtils;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimMemoFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimMemoFacade.java
@@ -25,7 +25,7 @@ import com.namo.spring.application.external.domain.group.ui.dto.GroupDiaryReques
 import com.namo.spring.application.external.domain.group.ui.dto.GroupDiaryResponse;
 import com.namo.spring.application.external.domain.group.ui.dto.GroupScheduleRequest;
 import com.namo.spring.application.external.domain.user.application.impl.UserService;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.application.external.global.utils.FileUtils;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimScheduleFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimScheduleFacade.java
@@ -31,7 +31,7 @@ import com.namo.spring.application.external.domain.individual.domain.Category;
 import com.namo.spring.application.external.domain.individual.domain.Schedule;
 import com.namo.spring.application.external.domain.individual.domain.constant.Location;
 import com.namo.spring.application.external.domain.individual.domain.constant.Period;
-import com.namo.spring.application.external.domain.user.application.impl.UserService;
+import com.namo.spring.application.external.api.user.service.UserService;
 import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.application.external.global.utils.FileUtils;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimScheduleFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/MoimScheduleFacade.java
@@ -32,7 +32,7 @@ import com.namo.spring.application.external.domain.individual.domain.Schedule;
 import com.namo.spring.application.external.domain.individual.domain.constant.Location;
 import com.namo.spring.application.external.domain.individual.domain.constant.Period;
 import com.namo.spring.application.external.domain.user.application.impl.UserService;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.application.external.global.utils.FileUtils;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/converter/MoimAndUserConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/converter/MoimAndUserConverter.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 import com.namo.spring.application.external.domain.group.domain.Moim;
 import com.namo.spring.application.external.domain.group.domain.MoimAndUser;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public class MoimAndUserConverter {
 	private MoimAndUserConverter() {

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/converter/MoimMemoLocationConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/converter/MoimMemoLocationConverter.java
@@ -9,7 +9,7 @@ import com.namo.spring.application.external.domain.group.domain.MoimMemoLocation
 import com.namo.spring.application.external.domain.group.domain.MoimMemoLocationAndUser;
 import com.namo.spring.application.external.domain.group.domain.MoimMemoLocationImg;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public class MoimMemoLocationConverter {
 	private MoimMemoLocationConverter() {

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/converter/MoimScheduleConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/converter/MoimScheduleConverter.java
@@ -15,7 +15,7 @@ import com.namo.spring.application.external.domain.group.domain.MoimScheduleAndU
 import com.namo.spring.application.external.domain.individual.domain.constant.Location;
 import com.namo.spring.application.external.domain.individual.domain.constant.Period;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public class MoimScheduleConverter {
 	private MoimScheduleConverter() {

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/converter/MoimScheduleResponseConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/converter/MoimScheduleResponseConverter.java
@@ -11,7 +11,7 @@ import com.namo.spring.application.external.domain.group.domain.MoimScheduleAndU
 
 import com.namo.spring.application.external.domain.individual.domain.Schedule;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public class MoimScheduleResponseConverter {
 	private MoimScheduleResponseConverter() {

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/impl/MoimAndUserService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/impl/MoimAndUserService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import com.namo.spring.application.external.domain.group.domain.Moim;
 import com.namo.spring.application.external.domain.group.domain.MoimAndUser;
 import com.namo.spring.application.external.domain.group.repository.group.MoimAndUserRepository;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.exception.GroupException;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/impl/MoimMemoLocationService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/impl/MoimMemoLocationService.java
@@ -12,7 +12,7 @@ import com.namo.spring.application.external.domain.group.domain.MoimSchedule;
 import com.namo.spring.application.external.domain.group.repository.diary.MoimMemoLocationAndUserRepository;
 import com.namo.spring.application.external.domain.group.repository.diary.MoimMemoLocationImgRepository;
 import com.namo.spring.application.external.domain.group.repository.diary.MoimMemoLocationRepository;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.exception.GroupException;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/impl/MoimScheduleAndUserService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/impl/MoimScheduleAndUserService.java
@@ -15,7 +15,7 @@ import com.namo.spring.application.external.domain.group.domain.MoimScheduleAlar
 import com.namo.spring.application.external.domain.group.domain.MoimScheduleAndUser;
 import com.namo.spring.application.external.domain.group.repository.schedule.MoimScheduleAlarmRepository;
 import com.namo.spring.application.external.domain.group.repository.schedule.MoimScheduleAndUserRepository;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.exception.GroupException;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/impl/MoimScheduleService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/application/impl/MoimScheduleService.java
@@ -10,7 +10,7 @@ import com.namo.spring.application.external.domain.group.repository.schedule.Moi
 import com.namo.spring.application.external.domain.group.domain.MoimSchedule;
 import com.namo.spring.application.external.domain.group.domain.MoimScheduleAndUser;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.exception.GroupException;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/Moim.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/Moim.java
@@ -17,7 +17,7 @@ import jakarta.persistence.Table;
 
 import com.namo.spring.application.external.domain.group.domain.constant.MoimStatus;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/Moim.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/Moim.java
@@ -19,7 +19,7 @@ import com.namo.spring.application.external.domain.group.domain.constant.MoimSta
 
 import com.namo.spring.application.external.domain.user.domain.User;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimAndUser.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimAndUser.java
@@ -10,7 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimAndUser.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimAndUser.java
@@ -12,7 +12,7 @@ import jakarta.persistence.Table;
 
 import com.namo.spring.application.external.domain.user.domain.User;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemo.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemo.java
@@ -1,6 +1,6 @@
 package com.namo.spring.application.external.domain.group.domain;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemoLocation.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemoLocation.java
@@ -14,7 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemoLocationAndUser.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemoLocationAndUser.java
@@ -10,7 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemoLocationAndUser.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemoLocationAndUser.java
@@ -12,7 +12,7 @@ import jakarta.persistence.Table;
 
 import com.namo.spring.application.external.domain.user.domain.User;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemoLocationImg.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimMemoLocationImg.java
@@ -10,7 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimSchedule.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimSchedule.java
@@ -23,7 +23,7 @@ import com.namo.spring.application.external.domain.group.domain.constant.MoimSch
 import com.namo.spring.application.external.domain.individual.domain.constant.Location;
 import com.namo.spring.application.external.domain.individual.domain.constant.Period;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimScheduleAndUser.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimScheduleAndUser.java
@@ -22,7 +22,7 @@ import com.namo.spring.application.external.domain.individual.domain.Category;
 
 import com.namo.spring.application.external.domain.user.domain.User;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimScheduleAndUser.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/domain/MoimScheduleAndUser.java
@@ -20,7 +20,7 @@ import com.namo.spring.application.external.domain.group.domain.constant.Visible
 
 import com.namo.spring.application.external.domain.individual.domain.Category;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/diary/MoimMemoLocationAndUserRepository.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/diary/MoimMemoLocationAndUserRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import com.namo.spring.application.external.domain.group.domain.MoimMemoLocation;
 import com.namo.spring.application.external.domain.group.domain.MoimMemoLocationAndUser;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public interface MoimMemoLocationAndUserRepository extends JpaRepository<MoimMemoLocationAndUser, Long> {
 	@Modifying

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/group/MoimAndUserRepository.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/group/MoimAndUserRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import com.namo.spring.application.external.domain.group.domain.Moim;
 import com.namo.spring.application.external.domain.group.domain.MoimAndUser;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public interface MoimAndUserRepository extends JpaRepository<MoimAndUser, Long> {
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/schedule/MoimScheduleAndUserRepository.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/schedule/MoimScheduleAndUserRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.namo.spring.application.external.domain.group.domain.MoimSchedule;
 import com.namo.spring.application.external.domain.group.domain.MoimScheduleAndUser;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public interface MoimScheduleAndUserRepository
 	extends JpaRepository<MoimScheduleAndUser, Long>, MoimScheduleAndUserRepositoryCustom {

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/schedule/MoimScheduleAndUserRepositoryCustom.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/schedule/MoimScheduleAndUserRepositoryCustom.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.namo.spring.application.external.domain.group.domain.MoimScheduleAndUser;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public interface MoimScheduleAndUserRepositoryCustom {
 	List<MoimScheduleAndUser> findMoimScheduleAndUserWithMoimScheduleByUsersAndDates(LocalDateTime startDate,

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/schedule/MoimScheduleAndUserRepositoryImpl.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/group/repository/schedule/MoimScheduleAndUserRepositoryImpl.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.namo.spring.application.external.domain.group.domain.MoimScheduleAndUser;
 import com.namo.spring.application.external.domain.group.domain.constant.VisibleStatus;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/CategoryFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/CategoryFacade.java
@@ -15,7 +15,7 @@ import com.namo.spring.application.external.domain.individual.ui.dto.CategoryReq
 import com.namo.spring.application.external.domain.individual.ui.dto.CategoryResponse;
 
 import com.namo.spring.application.external.domain.user.application.impl.UserService;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/CategoryFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/CategoryFacade.java
@@ -14,7 +14,7 @@ import com.namo.spring.application.external.domain.individual.domain.Palette;
 import com.namo.spring.application.external.domain.individual.ui.dto.CategoryRequest;
 import com.namo.spring.application.external.domain.individual.ui.dto.CategoryResponse;
 
-import com.namo.spring.application.external.domain.user.application.impl.UserService;
+import com.namo.spring.application.external.api.user.service.UserService;
 import com.namo.spring.db.mysql.domains.user.domain.User;
 
 import lombok.RequiredArgsConstructor;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/DiaryFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/DiaryFacade.java
@@ -17,7 +17,7 @@ import com.namo.spring.application.external.domain.individual.domain.Schedule;
 import com.namo.spring.application.external.domain.individual.ui.dto.DiaryResponse;
 
 import com.namo.spring.application.external.domain.user.application.impl.UserService;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.application.external.global.utils.FileUtils;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/DiaryFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/DiaryFacade.java
@@ -16,7 +16,7 @@ import com.namo.spring.application.external.domain.individual.domain.Image;
 import com.namo.spring.application.external.domain.individual.domain.Schedule;
 import com.namo.spring.application.external.domain.individual.ui.dto.DiaryResponse;
 
-import com.namo.spring.application.external.domain.user.application.impl.UserService;
+import com.namo.spring.application.external.api.user.service.UserService;
 import com.namo.spring.db.mysql.domains.user.domain.User;
 
 import com.namo.spring.application.external.global.common.constant.FilePath;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/ScheduleFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/ScheduleFacade.java
@@ -27,7 +27,7 @@ import com.namo.spring.application.external.domain.individual.domain.Schedule;
 import com.namo.spring.application.external.domain.individual.domain.constant.Period;
 import com.namo.spring.application.external.domain.individual.ui.dto.ScheduleRequest;
 import com.namo.spring.application.external.domain.individual.ui.dto.ScheduleResponse;
-import com.namo.spring.application.external.domain.user.application.impl.UserService;
+import com.namo.spring.application.external.api.user.service.UserService;
 import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.application.external.global.utils.FileUtils;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/ScheduleFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/ScheduleFacade.java
@@ -28,7 +28,7 @@ import com.namo.spring.application.external.domain.individual.domain.constant.Pe
 import com.namo.spring.application.external.domain.individual.ui.dto.ScheduleRequest;
 import com.namo.spring.application.external.domain.individual.ui.dto.ScheduleResponse;
 import com.namo.spring.application.external.domain.user.application.impl.UserService;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.application.external.global.common.constant.FilePath;
 import com.namo.spring.application.external.global.utils.FileUtils;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/converter/CategoryConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/converter/CategoryConverter.java
@@ -5,7 +5,7 @@ import com.namo.spring.application.external.domain.individual.domain.Palette;
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryKind;
 import com.namo.spring.application.external.domain.individual.ui.dto.CategoryRequest;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public class CategoryConverter {
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/converter/ScheduleConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/converter/ScheduleConverter.java
@@ -5,7 +5,7 @@ import com.namo.spring.application.external.domain.individual.domain.constant.Pe
 import com.namo.spring.application.external.domain.individual.ui.dto.ScheduleRequest;
 import com.namo.spring.application.external.domain.individual.domain.Category;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public class ScheduleConverter {
 	public static Period toPeriod(ScheduleRequest.PostScheduleDto dto) {

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/impl/CategoryService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/impl/CategoryService.java
@@ -12,7 +12,7 @@ import com.namo.spring.application.external.domain.individual.domain.constant.Ca
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryStatus;
 import com.namo.spring.application.external.domain.individual.repository.category.CategoryRepository;
 import com.namo.spring.application.external.domain.individual.ui.dto.CategoryRequest;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.exception.IndividualException;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/impl/ScheduleService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/application/impl/ScheduleService.java
@@ -10,7 +10,7 @@ import com.namo.spring.application.external.domain.individual.domain.Schedule;
 import com.namo.spring.application.external.domain.individual.repository.schedule.ScheduleRepository;
 import com.namo.spring.application.external.domain.individual.ui.dto.DiaryResponse;
 import com.namo.spring.application.external.domain.individual.ui.dto.ScheduleResponse;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.exception.IndividualException;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Alarm.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Alarm.java
@@ -12,7 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Category.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Category.java
@@ -13,7 +13,7 @@ import jakarta.persistence.ManyToOne;
 
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryKind;
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryStatus;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Category.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Category.java
@@ -14,7 +14,7 @@ import jakarta.persistence.ManyToOne;
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryKind;
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryStatus;
 import com.namo.spring.application.external.domain.user.domain.User;
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Image.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Image.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Schedule.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Schedule.java
@@ -19,7 +19,7 @@ import jakarta.persistence.OneToMany;
 import com.namo.spring.application.external.domain.individual.domain.constant.Location;
 import com.namo.spring.application.external.domain.individual.domain.constant.Period;
 import com.namo.spring.core.common.exception.IndividualException;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 import com.namo.spring.core.common.code.status.ErrorStatus;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Schedule.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/domain/Schedule.java
@@ -21,7 +21,7 @@ import com.namo.spring.application.external.domain.individual.domain.constant.Pe
 import com.namo.spring.core.common.exception.IndividualException;
 import com.namo.spring.application.external.domain.user.domain.User;
 
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 
 import lombok.AccessLevel;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/category/CategoryRepository.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/category/CategoryRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.namo.spring.application.external.domain.individual.domain.Category;
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryStatus;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public interface CategoryRepository extends JpaRepository<Category, Long>, CategoryRepositoryCustom {
 	List<Category> findCategoriesByUserIdAndStatusEquals(Long userId, CategoryStatus status);

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/category/CategoryRepositoryCustom.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/category/CategoryRepositoryCustom.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param;
 import com.namo.spring.application.external.domain.individual.domain.Category;
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryKind;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public interface CategoryRepositoryCustom {
 	List<Category> findMoimCategoriesByUsers(@Param("users") List<User> users, @Param("kind") CategoryKind kind);

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/category/CategoryRepositoryImpl.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/category/CategoryRepositoryImpl.java
@@ -8,7 +8,7 @@ import jakarta.persistence.EntityManager;
 
 import com.namo.spring.application.external.domain.individual.domain.Category;
 import com.namo.spring.application.external.domain.individual.domain.constant.CategoryKind;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 public class CategoryRepositoryImpl implements CategoryRepositoryCustom {

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/schedule/ScheduleRepository.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/schedule/ScheduleRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.namo.spring.application.external.domain.individual.domain.Schedule;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long>, ScheduleRepositoryCustom {
 	@Query("select s from Schedule s join fetch s.user where s.user in :users and s.category.share = true ")

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/schedule/ScheduleRepositoryCustom.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/schedule/ScheduleRepositoryCustom.java
@@ -9,7 +9,7 @@ import com.namo.spring.application.external.domain.individual.domain.Schedule;
 import com.namo.spring.application.external.domain.individual.ui.dto.DiaryResponse;
 import com.namo.spring.application.external.domain.individual.ui.dto.ScheduleResponse;
 
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public interface ScheduleRepositoryCustom {
 	List<ScheduleResponse.GetScheduleDto> findSchedulesByUserId(User user, LocalDateTime startDate,

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/schedule/ScheduleRepositoryImpl.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/individual/repository/schedule/ScheduleRepositoryImpl.java
@@ -24,7 +24,7 @@ import com.namo.spring.application.external.domain.individual.application.conver
 import com.namo.spring.application.external.domain.individual.domain.Schedule;
 import com.namo.spring.application.external.domain.individual.ui.dto.DiaryResponse;
 import com.namo.spring.application.external.domain.individual.ui.dto.ScheduleResponse;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/application/UserFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/application/UserFacade.java
@@ -39,10 +39,10 @@ import com.namo.spring.application.external.domain.user.application.converter.Te
 import com.namo.spring.application.external.domain.user.application.converter.UserConverter;
 import com.namo.spring.application.external.domain.user.application.converter.UserResponseConverter;
 import com.namo.spring.application.external.domain.user.application.impl.UserService;
-import com.namo.spring.application.external.domain.user.domain.Term;
-import com.namo.spring.application.external.domain.user.domain.User;
-import com.namo.spring.application.external.domain.user.domain.constant.SocialType;
-import com.namo.spring.application.external.domain.user.domain.constant.UserStatus;
+import com.namo.spring.db.mysql.domains.user.domain.Term;
+import com.namo.spring.db.mysql.domains.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.type.SocialType;
+import com.namo.spring.db.mysql.domains.user.type.UserStatus;
 import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
 import com.namo.spring.application.external.domain.user.ui.dto.UserResponse;
 import com.namo.spring.application.external.global.common.constant.FilePath;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/application/converter/TermConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/application/converter/TermConverter.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import com.namo.spring.application.external.domain.user.domain.Term;
-import com.namo.spring.application.external.domain.user.domain.constant.Content;
-import com.namo.spring.application.external.domain.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.domain.Term;
+import com.namo.spring.db.mysql.domains.user.type.Content;
+import com.namo.spring.db.mysql.domains.user.domain.User;
 import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
 import com.namo.spring.application.external.domain.user.ui.dto.UserResponse;
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/application/converter/UserConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/application/converter/UserConverter.java
@@ -2,9 +2,9 @@ package com.namo.spring.application.external.domain.user.application.converter;
 
 import java.util.Map;
 
-import com.namo.spring.application.external.domain.user.domain.constant.UserStatus;
-import com.namo.spring.application.external.domain.user.domain.User;
-import com.namo.spring.application.external.domain.user.domain.constant.SocialType;
+import com.namo.spring.db.mysql.domains.user.type.UserStatus;
+import com.namo.spring.db.mysql.domains.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.type.SocialType;
 
 public class UserConverter {
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/application/impl/UserService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/application/impl/UserService.java
@@ -19,12 +19,12 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-import com.namo.spring.application.external.domain.user.domain.Term;
-import com.namo.spring.application.external.domain.user.domain.User;
-import com.namo.spring.application.external.domain.user.domain.constant.SocialType;
-import com.namo.spring.application.external.domain.user.domain.constant.UserStatus;
-import com.namo.spring.application.external.domain.user.repository.TermRepository;
-import com.namo.spring.application.external.domain.user.repository.UserRepository;
+import com.namo.spring.db.mysql.domains.user.domain.Term;
+import com.namo.spring.db.mysql.domains.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.type.SocialType;
+import com.namo.spring.db.mysql.domains.user.type.UserStatus;
+import com.namo.spring.db.mysql.domains.user.repository.TermRepository;
+import com.namo.spring.db.mysql.domains.user.repository.UserRepository;
 import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
 import com.namo.spring.application.external.global.utils.JwtUtils;
 import com.namo.spring.client.social.common.properties.AppleProperties;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/Term.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/Term.java
@@ -14,7 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 import com.namo.spring.application.external.domain.user.domain.constant.Content;
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/User.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/User.java
@@ -12,8 +12,7 @@ import jakarta.persistence.UniqueConstraint;
 
 import com.namo.spring.application.external.domain.user.domain.constant.SocialType;
 import com.namo.spring.application.external.domain.user.domain.constant.UserStatus;
-
-import com.namo.spring.application.external.global.common.entity.BaseTimeEntity;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/constant/Content.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/constant/Content.java
@@ -1,5 +1,0 @@
-package com.namo.spring.application.external.domain.user.domain.constant;
-
-public enum Content {
-	TERMS_OF_USE, PERSONAL_INFORMATION_COLLECTION
-}

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/constant/SocialType.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/constant/SocialType.java
@@ -1,5 +1,0 @@
-package com.namo.spring.application.external.domain.user.domain.constant;
-
-public enum SocialType {
-	KAKAO, NAVER, APPLE
-}

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/constant/UserStatus.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/domain/constant/UserStatus.java
@@ -1,5 +1,0 @@
-package com.namo.spring.application.external.domain.user.domain.constant;
-
-public enum UserStatus {
-	ACTIVE, INACTIVE
-}

--- a/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/ui/AuthController.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/domain/user/ui/AuthController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.namo.spring.application.external.domain.user.application.UserFacade;
-import com.namo.spring.application.external.domain.user.domain.constant.SocialType;
+import com.namo.spring.db.mysql.domains.user.type.SocialType;
 import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
 import com.namo.spring.application.external.domain.user.ui.dto.UserResponse;
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/global/utils/SocialUtils.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/global/utils/SocialUtils.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
-import com.namo.spring.application.external.domain.user.ui.dto.UserRequest;
+import com.namo.spring.application.external.api.user.dto.UserRequest;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.exception.UtilsException;
 

--- a/storage/README.md
+++ b/storage/README.md
@@ -46,4 +46,8 @@
 
 ## Update History
 
-- 2024.06.11: `core` 모듈 및 `core-common` 모듈 생성
+- 2024.06.11
+  - `core` 모듈 및 `core-common` 모듈 생성
+- 2024.06.18
+  - `jpa` 관련 설정 이관 (`external-api` 모듈에서 이동)
+  - `user` 도메인 모듈 분리 (`entity`, `repository` 패키지 `external-api` 모듈에서 이동)

--- a/storage/db-mysql/build.gradle
+++ b/storage/db-mysql/build.gradle
@@ -1,19 +1,15 @@
-plugins {
-    id 'java'
-}
-
-group = 'com.namo.spring.db.mysql'
-version = '0.0.1-SNAPSHOT'
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-}
+    // subproject
+    implementation project(':core:namo-common')
 
-test {
-    useJUnitPlatform()
+    // data
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '6.2.0.CR3' // point 저장
+
+    // querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/Main.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/Main.java
@@ -1,7 +1,0 @@
-package com.namo.spring.db.mysql;
-
-public class Main {
-	public static void main(String[] args) {
-		System.out.println("Hello world!");
-	}
-}

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/common/model/BaseTimeEntity.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/common/model/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.global.common.entity;
+package com.namo.spring.db.mysql.common.model;
 
 import java.time.LocalDateTime;
 

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/config/JpaConfig.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/config/JpaConfig.java
@@ -1,9 +1,9 @@
-package com.namo.spring.application.external.global.config.properties;
+package com.namo.spring.db.mysql.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class JpaAuditingConfig {
+public class JpaConfig {
 }

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/domain/Term.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/domain/Term.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.domain;
+package com.namo.spring.db.mysql.domains.user.domain;
 
 import java.time.LocalDateTime;
 
@@ -13,7 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
-import com.namo.spring.application.external.domain.user.domain.constant.Content;
+import com.namo.spring.db.mysql.domains.user.type.Content;
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;
@@ -21,9 +21,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 네이밍 마음에 드는지 좀 봐주세요.
- */
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/domain/User.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/domain/User.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.domain;
+package com.namo.spring.db.mysql.domains.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,8 +10,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
-import com.namo.spring.application.external.domain.user.domain.constant.SocialType;
-import com.namo.spring.application.external.domain.user.domain.constant.UserStatus;
+import com.namo.spring.db.mysql.domains.user.type.SocialType;
+import com.namo.spring.db.mysql.domains.user.type.UserStatus;
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 
 import lombok.AccessLevel;

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/repository/TermRepository.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/repository/TermRepository.java
@@ -1,13 +1,13 @@
-package com.namo.spring.application.external.domain.user.repository;
+package com.namo.spring.db.mysql.domains.user.repository;
 
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.namo.spring.application.external.domain.user.domain.Term;
-import com.namo.spring.application.external.domain.user.domain.User;
-import com.namo.spring.application.external.domain.user.domain.constant.Content;
+import com.namo.spring.db.mysql.domains.user.domain.Term;
+import com.namo.spring.db.mysql.domains.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.type.Content;
 
 public interface TermRepository extends JpaRepository<Term, Long> {
 	Optional<Term> findTermByContentAndUser(Content content, User user);

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/repository/UserRepository.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/repository/UserRepository.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.domain.user.repository;
+package com.namo.spring.db.mysql.domains.user.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -7,9 +7,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import com.namo.spring.application.external.domain.user.domain.User;
-import com.namo.spring.application.external.domain.user.domain.constant.SocialType;
-import com.namo.spring.application.external.domain.user.domain.constant.UserStatus;
+import com.namo.spring.db.mysql.domains.user.domain.User;
+import com.namo.spring.db.mysql.domains.user.type.SocialType;
+import com.namo.spring.db.mysql.domains.user.type.UserStatus;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findUserByEmail(String email);

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/type/Content.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/type/Content.java
@@ -1,0 +1,5 @@
+package com.namo.spring.db.mysql.domains.user.type;
+
+public enum Content {
+	TERMS_OF_USE, PERSONAL_INFORMATION_COLLECTION
+}

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/type/SocialType.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/type/SocialType.java
@@ -1,0 +1,5 @@
+package com.namo.spring.db.mysql.domains.user.type;
+
+public enum SocialType {
+	KAKAO, NAVER, APPLE
+}

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/type/UserStatus.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/user/type/UserStatus.java
@@ -1,0 +1,5 @@
+package com.namo.spring.db.mysql.domains.user.type;
+
+public enum UserStatus {
+	ACTIVE, INACTIVE
+}


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [x] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- db 관련 설정 이동 (db-mysql 모듈로)
  - japConfig
  - baseTimeEntity
  - build.gradle
- User 도메인 분리
  - external-api : api 및 비지니스 로직
  - db-mysql : 도메인 로직

### external-api 모듈 리펙토링 구조 예시

```
external-api
├── src
│   ├── main
│   │   ├──  java.com.namo.spring.application.external
│   │   │   ├── api # 도메인 별로 패키지를 나누어 구성한다.
│   │   │   │   ├── ${도메인 명}
│   │   │   │   │   ├── contoller
│   │   │   │   │   ├── converter
│   │   │   │   │   ├── dto
│   │   │   │   │   ├── facade
│   │   │   │   │   └── service
```

### db-mysql 모듈 리펙토링 구조 예시

```
db-mysql
├── src
│   ├── main
│   │   ├──  java.com.namo.spring.db.mysql
│   │   │   ├─ domains # 도메인 별로 패키지를 나누어 구성한다.
│   │   │   │   ├── ${도메인 명}
│   │   │   │   │   ├── domain
│   │   │   │   │   ├── dto
│   │   │   │   │   ├── repository
│   │   │   │   │   └── type
│   │   │   ├── common
│   │   │   │   └──  model  # baseEntity
│   │   │   ├── config
```

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 세부적인 code 보다는 전체적인 패키지 구조에 대해서 봐주시면 좋을 것 같습니다!

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 고민 중인 사항

- db-mysql 모듈에도 service를 만들어서 사용해볼까에 대해서 고민중입니다. 만약 그렇게 되면 application 계층의 모듈들이 resporitory를 직접 호출하는 것이 아니라 storage 모듈에서 제공하는 service를 통해 repository를 호출하는 방식으로 구조가 변경하게 됩니다.
  - 장점 : 더욱 확장성 있는 코드 구조를 가져갈 수 있다.
  - 고민되는 부분 : 확장성을 위해 코드의 복잡도가 올라가게 되는데, 해당 복잡도를 감수하면서 변경해야하는가?
  - 예시 : https://github.com/CollaBu/pennyway-was/blob/dev/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java

## 관련 이슈

- close #139 
