### PR TITLE
[Bug Fix/163] flyway 초기 스키마 설정 파일 테이블 구조 오류 수정

### DIFF
--- a/storage/db-mysql/src/main/resources/db/migration/V1.0.0__Initial_schema.sql
+++ b/storage/db-mysql/src/main/resources/db/migration/V1.0.0__Initial_schema.sql
@@ -237,14 +237,12 @@ CREATE TABLE IF NOT EXISTS `moim_memo_location`
     `moim_memo_location_id` bigint NOT NULL AUTO_INCREMENT,
     `created_date`          datetime(6)  DEFAULT NULL,
     `last_modified_date`    datetime(6)  DEFAULT NULL,
-    `kakao_location_id`     varchar(255) DEFAULT NULL,
-    `location_name`         varchar(255) DEFAULT NULL,
-    `x`                     double       DEFAULT NULL,
-    `y`                     double       DEFAULT NULL,
-    `moim_id`               bigint       DEFAULT NULL,
+    `name`                  varchar(255) DEFAULT NULL,
+    `total_amount`          int          DEFAULT NULL,
+    `moim_memo_id`          bigint       DEFAULT NULL,
     PRIMARY KEY (`moim_memo_location_id`),
-    KEY `FKqxqxqxqxqxqxqxqxqxqxqxqxq` (`moim_id`),
-    CONSTRAINT `FKqxqxqxqxqxqxqxqxqxqxqxqxq` FOREIGN KEY (`moim_id`) REFERENCES `moim` (`moim_id`)
+    KEY `FKbn44e9cywgvgf5n3imksoe5cj` (`moim_memo_id`),
+    CONSTRAINT `FKbn44e9cywgvgf5n3imksoe5cj` FOREIGN KEY (`moim_memo_id`) REFERENCES `moim_memo` (`moim_memo_id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_0900_ai_ci;
@@ -252,13 +250,12 @@ CREATE TABLE IF NOT EXISTS `moim_memo_location`
 -- Table structure for table `moim_memo_location_and_user`
 CREATE TABLE IF NOT EXISTS `moim_memo_location_and_user`
 (
-    `moim_memo_location_and_user_id` bigint NOT NULL AUTO_INCREMENT,
-    `created_date`                   datetime(6)  DEFAULT NULL,
-    `last_modified_date`             datetime(6)  DEFAULT NULL,
-    `memo`                           varchar(255) DEFAULT NULL,
-    `moim_memo_location_id`          bigint       DEFAULT NULL,
-    `user_id`                        bigint       DEFAULT NULL,
-    PRIMARY KEY (`moim_memo_location_and_user_id`),
+    `moim_memo_location_user_id` bigint NOT NULL AUTO_INCREMENT,
+    `created_date`               datetime(6) DEFAULT NULL,
+    `last_modified_date`         datetime(6) DEFAULT NULL,
+    `moim_memo_location_id`      bigint      DEFAULT NULL,
+    `user_id`                    bigint      DEFAULT NULL,
+    PRIMARY KEY (`moim_memo_location_user_id`),
     KEY `FKfxd4ff8np0iwton3jyednn3kt` (`moim_memo_location_id`),
     KEY `FKm6d9qu3ag3fd1gfb680wpbquh` (`user_id`),
     CONSTRAINT `FKfxd4ff8np0iwton3jyednn3kt` FOREIGN KEY (`moim_memo_location_id`) REFERENCES `moim_memo_location` (`moim_memo_location_id`),


### PR DESCRIPTION
<footer>
- 관련: #163

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [X] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
-  flyway 초기 스키마 설정 파일 테이블 구조 수정
  - moim_memo_location , moim_memo_location_and_user의 테이블 구조 오류 수정

## Requirements for Reviewer
-  이미 flyway 적용 후 application을 실행시키셨다면, flyway_schema_history 테이블 삭제 후 실행 해주세요!
    -  이미 적용된 sql 파일을 수정하고 실행시키면 오류가 발생합니다.
    -  원칙적으로 한 번 생성된 파일은 수정이 불가하나, 초기 스키마 파일이기 때문에 수정하였습니다.

## PR Log

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #163 
