### PR TITLE
[Feature/174] 기록 이미지 개별 삭제 API 구현

### DIFF
--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
@@ -142,7 +142,7 @@ public class DiaryController {
 	}
 
 	@Operation(summary = "일정 기록 이미지 삭제", description = "일정 이미지 개별 삭제 API")
-	@DeleteMapping("/{scheduleId}/image/{imgUrl}")
+	@DeleteMapping("/{scheduleId}/image/{imgId}")
 	@ApiErrorCodes(value = {
 		ErrorStatus.NOT_FOUND_IMAGE,
 		ErrorStatus.NOT_IMAGE_IN_DIARY,
@@ -150,9 +150,9 @@ public class DiaryController {
 	})
 	public ResponseDto<String> deleteDiaryImage(
 		@Parameter(description = "일정 ID") @PathVariable("scheduleId") Long scheduleId,
-		@Parameter(description = "이미지 URL") @PathVariable("imgUrl") String imgUrl
+		@Parameter(description = "이미지 ID") @PathVariable("imgID") String imgId
 	) {
-		diaryFacade.removeDiaryImage(scheduleId, imgUrl);
+		diaryFacade.removeDiaryImage(scheduleId, imgId);
 		return ResponseDto.onSuccess("삭제에 성공하셨습니다.");
 	}
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
@@ -150,7 +150,7 @@ public class DiaryController {
 	})
 	public ResponseDto<String> deleteDiaryImage(
 		@Parameter(description = "일정 ID") @PathVariable("scheduleId") Long scheduleId,
-		@Parameter(description = "이미지 ID") @PathVariable("imgID") String imgId
+		@Parameter(description = "이미지 ID") @PathVariable("imgID") Long imgId
 	) {
 		diaryFacade.removeDiaryImage(scheduleId, imgId);
 		return ResponseDto.onSuccess("삭제에 성공하셨습니다.");

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
@@ -3,8 +3,6 @@ package com.namo.spring.application.external.api.individual.controller;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,17 +16,17 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import com.namo.spring.application.external.api.individual.facade.DiaryFacade;
 import com.namo.spring.application.external.api.individual.dto.DiaryResponse;
+import com.namo.spring.application.external.api.individual.facade.DiaryFacade;
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
 import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
 import com.namo.spring.application.external.global.utils.Converter;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.response.ResponseDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -142,4 +140,15 @@ public class DiaryController {
 		diaryFacade.removeDiary(scheduleId);
 		return ResponseDto.onSuccess("삭제에 성공하셨습니다.");
 	}
+
+	@Operation(summary = "일정 기록 이미지 삭제", description = "일정 이미지 개별 삭제 API")
+	@DeleteMapping("/{scheduleId}/image/{imgUrl}")
+	public ResponseDto<String> deleteDiaryImage(
+		@Parameter(description = "일정 ID") @PathVariable("scheduleId") Long scheduleId,
+		@Parameter(description = "이미지 URL") @PathVariable("imgUrl") String imgUrl
+	) {
+		// diaryFacade.removeDiaryImage(scheduleId, imgUrl);
+		return ResponseDto.onSuccess("삭제에 성공하셨습니다.");
+	}
+
 }

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
@@ -143,11 +143,16 @@ public class DiaryController {
 
 	@Operation(summary = "일정 기록 이미지 삭제", description = "일정 이미지 개별 삭제 API")
 	@DeleteMapping("/{scheduleId}/image/{imgUrl}")
+	@ApiErrorCodes(value = {
+		ErrorStatus.NOT_FOUND_IMAGE,
+		ErrorStatus.NOT_IMAGE_IN_DIARY,
+		ErrorStatus.INTERNET_SERVER_ERROR
+	})
 	public ResponseDto<String> deleteDiaryImage(
 		@Parameter(description = "일정 ID") @PathVariable("scheduleId") Long scheduleId,
 		@Parameter(description = "이미지 URL") @PathVariable("imgUrl") String imgUrl
 	) {
-		// diaryFacade.removeDiaryImage(scheduleId, imgUrl);
+		diaryFacade.removeDiaryImage(scheduleId, imgUrl);
 		return ResponseDto.onSuccess("삭제에 성공하셨습니다.");
 	}
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/controller/DiaryController.java
@@ -150,7 +150,7 @@ public class DiaryController {
 	})
 	public ResponseDto<String> deleteDiaryImage(
 		@Parameter(description = "일정 ID") @PathVariable("scheduleId") Long scheduleId,
-		@Parameter(description = "이미지 ID") @PathVariable("imgID") Long imgId
+		@Parameter(description = "이미지 ID") @PathVariable("imgId") Long imgId
 	) {
 		diaryFacade.removeDiaryImage(scheduleId, imgId);
 		return ResponseDto.onSuccess("삭제에 성공하셨습니다.");

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/converter/DiaryResponseConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/converter/DiaryResponseConverter.java
@@ -1,6 +1,5 @@
 package com.namo.spring.application.external.api.individual.converter;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Slice;
@@ -33,12 +32,20 @@ public class DiaryResponseConverter {
 	}
 
 	public static DiaryResponse.GetDiaryByScheduleDto toGetDiaryByScheduleRes(
-		Schedule schedule,
-		List<String> imgUrls
+		Schedule schedule
 	) {
 		return DiaryResponse.GetDiaryByScheduleDto.builder()
 			.contents(schedule.getContents())
-			.urls(imgUrls)
+			.images(schedule.getImages().stream()
+				.map(DiaryResponseConverter::toDiaryImageDto)
+				.collect(Collectors.toList()))
+			.build();
+	}
+
+	public static DiaryResponse.DiaryImageDto toDiaryImageDto(Image image) {
+		return DiaryResponse.DiaryImageDto.builder()
+			.id(image.getId().toString())
+			.url(image.getImgUrl())
 			.build();
 	}
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/dto/DiaryResponse.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/dto/DiaryResponse.java
@@ -44,7 +44,12 @@ public class DiaryResponse {
 	@Builder
 	public static class GetDiaryByScheduleDto {
 		private String contents;
-		private List<String> urls;
+		private List<DiaryImageDto> images;
+	}
+
+	public static class DiaryImageDto {
+		private String id;
+		private String url;
 	}
 
 }

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/dto/DiaryResponse.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/dto/DiaryResponse.java
@@ -47,6 +47,9 @@ public class DiaryResponse {
 		private List<DiaryImageDto> images;
 	}
 
+	@AllArgsConstructor
+	@Getter
+	@Builder
 	public static class DiaryImageDto {
 		private String id;
 		private String url;

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/facade/DiaryFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/facade/DiaryFacade.java
@@ -85,8 +85,9 @@ public class DiaryFacade {
 	}
 
 	@Transactional
-	public void removeDiaryImage(Long scheduleId, String imgUrl) {
-		Image img = imageService.getImage(imgUrl);
+	public void removeDiaryImage(Long scheduleId, Long imgId) {
+		Image img = imageService.getImage(imgId);
+		String imgUrl = img.getImgUrl();
 		imageService.removeImage(scheduleId, img);
 		fileUtils.delete(imgUrl, FilePath.INVITATION_ACTIVITY_IMG);
 	}

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/facade/DiaryFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/facade/DiaryFacade.java
@@ -14,8 +14,8 @@ import com.namo.spring.application.external.api.individual.dto.DiaryResponse;
 import com.namo.spring.application.external.api.individual.service.ImageService;
 import com.namo.spring.application.external.api.individual.service.ScheduleService;
 import com.namo.spring.application.external.api.user.service.UserService;
-import com.namo.spring.core.infra.common.constant.FilePath;
 import com.namo.spring.core.infra.common.aws.s3.FileUtils;
+import com.namo.spring.core.infra.common.constant.FilePath;
 import com.namo.spring.db.mysql.domains.individual.domain.Image;
 import com.namo.spring.db.mysql.domains.individual.domain.Schedule;
 import com.namo.spring.db.mysql.domains.user.domain.User;
@@ -82,5 +82,12 @@ public class DiaryFacade {
 			.toList();
 		imageService.removeImagesBySchedule(schedule);
 		fileUtils.deleteImages(urls, FilePath.INVITATION_ACTIVITY_IMG);
+	}
+
+	@Transactional
+	public void removeDiaryImage(Long scheduleId, String imgUrl) {
+		Image img = imageService.getImage(imgUrl);
+		imageService.removeImage(scheduleId, img);
+		fileUtils.delete(imgUrl, FilePath.INVITATION_ACTIVITY_IMG);
 	}
 }

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/facade/DiaryFacade.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/facade/DiaryFacade.java
@@ -66,11 +66,7 @@ public class DiaryFacade {
 	public DiaryResponse.GetDiaryByScheduleDto getDiaryBySchedule(Long scheduleId) {
 		Schedule schedule = scheduleService.getScheduleById(scheduleId);
 		schedule.existDairy(); //다이어리 없으면 exception발생
-		List<String> imgUrls = schedule.getImages().stream()
-			.map(Image::getImgUrl)
-			.toList();
-
-		return DiaryResponseConverter.toGetDiaryByScheduleRes(schedule, imgUrls);
+		return DiaryResponseConverter.toGetDiaryByScheduleRes(schedule);
 	}
 
 	@Transactional

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/service/ImageService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/service/ImageService.java
@@ -48,7 +48,10 @@ public class ImageService {
 		);
 	}
 
-	public void removeImage(Image img) {
+	public void removeImage(Long scheduleId, Image img) {
+		if (!img.getSchedule().getId().equals(scheduleId)) {
+			throw new IndividualException(ErrorStatus.NOT_IMAGE_IN_DIARY);
+		}
 		imageRepository.delete(img);
 	}
 }

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/service/ImageService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/service/ImageService.java
@@ -23,6 +23,11 @@ public class ImageService {
 			.orElseThrow(() -> new IndividualException(ErrorStatus.NOT_FOUND_IMAGE));
 	}
 
+	public Image getImage(String url) {
+		return imageRepository.findByImgUrl(url)
+			.orElseThrow(() -> new IndividualException(ErrorStatus.NOT_FOUND_IMAGE));
+	}
+
 	public List<Image> createImages(List<Image> imgs) {
 		return imageRepository.saveAll(imgs);
 	}

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/service/ImageService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/service/ImageService.java
@@ -5,6 +5,8 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.namo.spring.core.common.code.status.ErrorStatus;
+import com.namo.spring.core.common.exception.IndividualException;
 import com.namo.spring.db.mysql.domains.individual.domain.Image;
 import com.namo.spring.db.mysql.domains.individual.domain.Schedule;
 import com.namo.spring.db.mysql.domains.individual.repository.image.ImageRepository;
@@ -15,6 +17,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ImageService {
 	private final ImageRepository imageRepository;
+
+	public Image getImage(Long id) {
+		return imageRepository.findById(id)
+			.orElseThrow(() -> new IndividualException(ErrorStatus.NOT_FOUND_IMAGE));
+	}
 
 	public List<Image> createImages(List<Image> imgs) {
 		return imageRepository.saveAll(imgs);
@@ -34,5 +41,9 @@ public class ImageService {
 		schedules.forEach(schedule ->
 			imageRepository.deleteAll(schedule.getImages())
 		);
+	}
+
+	public void removeImage(Image img) {
+		imageRepository.delete(img);
 	}
 }

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -100,6 +100,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	 */
 	NOT_USERS_CATEGORY(HttpStatus.NOT_FOUND, "해당 유저의 카테고리가 아닙니다."),
 	NOT_USERS_IN_GROUP(HttpStatus.NOT_FOUND, "유저가 모임에 포함되어 있지 않습니다."),
+	NOT_IMAGE_IN_DIARY(HttpStatus.NOT_FOUND, "이미지가 다이어리에 포함되어 있지 않습니다."),
 
 	/**
 	 * 404 : 인프라 에러

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -72,6 +72,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	NOT_FOUND_GROUP_MEMO_FAILURE(HttpStatus.NOT_FOUND, "모임 메모를 찾을 수 없습니다."),
 	NOT_FOUND_GROUP_MEMO_LOCATION_FAILURE(HttpStatus.NOT_FOUND, "모임 장소를 찾을 수 없습니다."),
 	NOT_FOUND_COLOR(HttpStatus.NOT_FOUND, "색깔을 찾을 수 없습니다."),
+	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
 
 	/**
 	 * 404 : 예외 상황 에러

--- a/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/s3/FileUtils.java
+++ b/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/s3/FileUtils.java
@@ -103,7 +103,7 @@ public class FileUtils {
 		}
 	}
 
-	private void delete(String url, FilePath filePath) {
+	public void delete(String url, FilePath filePath) {
 		try {
 			String key = url.substring(url.lastIndexOf(filePath.getPath()));
 			if (!key.isEmpty()) {

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/individual/domain/Image.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/individual/domain/Image.java
@@ -25,7 +25,7 @@ public class Image extends BaseTimeEntity {
 	@Column(name = "image_id")
 	private Long id;
 
-	@Column(name = "img_url")
+	@Column(name = "img_url", unique = true)
 	private String imgUrl;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/individual/repository/image/ImageRepository.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/individual/repository/image/ImageRepository.java
@@ -11,4 +11,5 @@ import com.namo.spring.db.mysql.domains.individual.domain.Schedule;
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
 	Optional<List<Image>> findAllBySchedule(Schedule schedule);
 
+	Optional<Image> findByImgUrl(String url);
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [X] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [X] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 일정 개별 기록 조회 API Response DTO 수정 
  - images : {id, urls} 구조
- 일정 기록 이미지 개별 삭제 API 구현
  - /{scheduleId}/image/{imgId}

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 이미지 URL에 포함된 /와 같은 특수 문자는 %2F로 인코딩해야 PathVariable 값으로 사용할 수 있다.
  - imageId를 이용해 삭제하도록 구현하였습니다.
  - 이를 통해 일정 개별 기록 조회시 imageID가 함께 조회되도록 수정하였습니다.

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #174
