### PR TITLE
[Refactor/184] 개인 일정 기록 전체 조회 Response 리팩토링

### DIFF
--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/converter/DiaryResponseConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/converter/DiaryResponseConverter.java
@@ -42,8 +42,8 @@ public class DiaryResponseConverter {
 			.build();
 	}
 
-	public static DiaryResponse.DiaryImageDto toDiaryImageDto(Image image) {
-		return DiaryResponse.DiaryImageDto.builder()
+	public static DiaryResponse.DiaryImageByScheduleDto toDiaryImageDto(Image image) {
+		return DiaryResponse.DiaryImageByScheduleDto.builder()
 			.id(image.getId())
 			.url(image.getImgUrl())
 			.build();
@@ -54,9 +54,16 @@ public class DiaryResponseConverter {
 		return DiaryResponse.GetDiaryByUserDto.builder()
 			.scheduleId(diaryByUserDto.getScheduleId())
 			.contents(diaryByUserDto.getContents())
-			.urls(diaryByUserDto.getImages().stream()
-				.map(Image::getImgUrl)
-				.toList())
+			.images(diaryByUserDto.getImages().stream()
+				.map(DiaryResponseConverter::toDiaryImageByUserDto)
+				.collect(Collectors.toList()))
+			.build();
+	}
+
+	public static DiaryResponse.DiaryImageByUserDto toDiaryImageByUserDto(Image image) {
+		return DiaryResponse.DiaryImageByUserDto.builder()
+			.id(image.getId())
+			.url(image.getImgUrl())
 			.build();
 	}
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/converter/DiaryResponseConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/converter/DiaryResponseConverter.java
@@ -50,11 +50,11 @@ public class DiaryResponseConverter {
 	}
 
 	public static DiaryResponse.GetDiaryByUserDto toGetDiaryByUserRes(
-		ScheduleProjection.DiaryByUserDto diaryByUserDto) {
+		Schedule schedule) {
 		return DiaryResponse.GetDiaryByUserDto.builder()
-			.scheduleId(diaryByUserDto.getScheduleId())
-			.contents(diaryByUserDto.getContents())
-			.images(diaryByUserDto.getImages().stream()
+			.scheduleId(schedule.getId())
+			.contents(schedule.getContents())
+			.images(schedule.getImages().stream()
 				.map(DiaryResponseConverter::toDiaryImageByUserDto)
 				.collect(Collectors.toList()))
 			.build();

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/converter/DiaryResponseConverter.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/converter/DiaryResponseConverter.java
@@ -44,7 +44,7 @@ public class DiaryResponseConverter {
 
 	public static DiaryResponse.DiaryImageDto toDiaryImageDto(Image image) {
 		return DiaryResponse.DiaryImageDto.builder()
-			.id(image.getId().toString())
+			.id(image.getId())
 			.url(image.getImgUrl())
 			.build();
 	}

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/dto/DiaryResponse.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/dto/DiaryResponse.java
@@ -36,7 +36,15 @@ public class DiaryResponse {
 	public static class GetDiaryByUserDto {
 		private Long scheduleId;
 		private String contents;
-		private List<String> urls;
+		private List<DiaryImageByUserDto> images;
+	}
+
+	@AllArgsConstructor
+	@Getter
+	@Builder
+	public static class DiaryImageByUserDto {
+		private Long id;
+		private String url;
 	}
 
 	@AllArgsConstructor
@@ -44,13 +52,13 @@ public class DiaryResponse {
 	@Builder
 	public static class GetDiaryByScheduleDto {
 		private String contents;
-		private List<DiaryImageDto> images;
+		private List<DiaryImageByScheduleDto> images;
 	}
 
 	@AllArgsConstructor
 	@Getter
 	@Builder
-	public static class DiaryImageDto {
+	public static class DiaryImageByScheduleDto {
 		private Long id;
 		private String url;
 	}

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/dto/DiaryResponse.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/dto/DiaryResponse.java
@@ -51,7 +51,7 @@ public class DiaryResponse {
 	@Getter
 	@Builder
 	public static class DiaryImageDto {
-		private String id;
+		private Long id;
 		private String url;
 	}
 

--- a/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/service/ScheduleService.java
+++ b/application/external-api/src/main/java/com/namo/spring/application/external/api/individual/service/ScheduleService.java
@@ -76,7 +76,7 @@ public class ScheduleService {
 	}
 
 	public List<DiaryResponse.GetDiaryByUserDto> getAllDiariesByUser(User user) {
-		return scheduleRepository.findAllScheduleDiary(user)
+		return scheduleRepository.findAllScheduleByUser(user)
 			.stream()
 			.map(DiaryResponseConverter::toGetDiaryByUserRes)
 			.collect(Collectors.toList());

--- a/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/individual/repository/schedule/ScheduleRepository.java
+++ b/storage/db-mysql/src/main/java/com/namo/spring/db/mysql/domains/individual/repository/schedule/ScheduleRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.namo.spring.db.mysql.domains.individual.domain.Schedule;
-
 import com.namo.spring.db.mysql.domains.user.domain.User;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long>, ScheduleRepositoryCustom {
@@ -15,4 +14,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long>, Sched
 	List<Schedule> findSchedulesByUsers(@Param("users") List<User> users);
 
 	List<Schedule> findAllByUser(User user);
+
+	List<Schedule> findAllScheduleByUser(User user);
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [X] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 개인 일정 기록 전체 조회시 이미지 ID와 URL이 함께 조회
  - 기존에는 URL만 조회되어 추적에 문제
- QueryDSL을 사용한 쿼리에서 JPA로 변경 
  - 기존 에러 발생 

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #184 
