### PR TITLE
[Feature/280] 일기 보관함 조회 API 구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
@@ -1,5 +1,7 @@
 package com.namo.spring.application.external.api.record.Controller;
 
+import java.util.List;
+
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -72,10 +74,11 @@ public class DiaryController {
 
 	@Operation(summary = "기록 보관함 조회", description = "기록(일기) 보관함 조회 API 입니다. ")
 	@GetMapping("/archive")
-	public ResponseDto<DiaryResponse.DiaryArchiveDto> getDiaryArchive(
+	public ResponseDto<List<DiaryResponse.DiaryArchiveDto>> getDiaryArchive(
 		@AuthenticationPrincipal SecurityUserDetails memberInfo,
 		@ParameterObject Pageable pageable
 	) {
-		return ResponseDto.onSuccess(null);
+		return ResponseDto.onSuccess(diaryUseCase
+			.getDiaryArchiveDto(memberInfo.getUserId(), pageable));
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
@@ -49,6 +49,7 @@ public class DiaryController {
 	}
 
 	@PatchMapping("/{diaryId}")
+	@Operation(summary = "기록 수정", description = "기록(일기) 수정 API 입니다. 모든 이미지 URL을 새로 보내주어야 합니다.")
 	public ResponseDto<String> updateDiary(
 		@AuthenticationPrincipal SecurityUserDetails memberInfo,
 		@PathVariable Long diaryId,

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
@@ -2,8 +2,6 @@ package com.namo.spring.application.external.api.record.Controller;
 
 import java.util.List;
 
-import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.namo.spring.application.external.api.record.dto.DiaryRequest;
@@ -22,6 +21,7 @@ import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.response.ResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
@@ -50,6 +50,10 @@ public class DiaryController {
 
 	@PatchMapping("/{diaryId}")
 	@Operation(summary = "기록 수정", description = "기록(일기) 수정 API 입니다. 모든 이미지 URL을 새로 보내주어야 합니다.")
+	@ApiErrorCodes(value = {
+		ErrorStatus.NOT_FOUND_DIARY_FAILURE,
+		ErrorStatus.NOT_MY_DIARY_FAILURE,
+	})
 	public ResponseDto<String> updateDiary(
 		@AuthenticationPrincipal SecurityUserDetails memberInfo,
 		@PathVariable Long diaryId,
@@ -74,12 +78,20 @@ public class DiaryController {
 	}
 
 	@Operation(summary = "기록 보관함 조회", description = "기록(일기) 보관함 조회 API 입니다. ")
+	@ApiErrorCodes(value = {
+		ErrorStatus.NOT_FILTERTYPE_OF_ARCHIVE,
+	})
 	@GetMapping("/archive")
 	public ResponseDto<List<DiaryResponse.DiaryArchiveDto>> getDiaryArchive(
 		@AuthenticationPrincipal SecurityUserDetails memberInfo,
-		@ParameterObject Pageable pageable
+		@Parameter(description = "ScheduleName(스케쥴 이름 조회) || DiaryContent(일기 내용 조회) || MemberNickname (참여자 조회)")
+		@RequestParam(required = false) String filterType,
+		@Parameter(description = "각 필터에 맞는 검색 단어를 입력하시면 됩니다.")
+		@RequestParam(required = false) String keyword,
+		@Parameter(description = "1 부터 시작하는 page입니다. 5개의 일기씩 내림차순 조회됩니다. ")
+		@RequestParam int page
 	) {
 		return ResponseDto.onSuccess(diaryUseCase
-			.getDiaryArchiveDto(memberInfo.getUserId(), pageable));
+			.getDiaryArchiveDto(memberInfo.getUserId(), page, filterType, keyword));
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
@@ -31,7 +31,7 @@ public class DiaryResponseConverter {
 			.scheduleDate(participant.getSchedule().getPeriod().getStartDate())
 			.scheduleId(participant.getSchedule().getId())
 			.title(participant.getSchedule().getTitle())
-			.diarySummary(toDiarySummaryDto(participant.getDiaries().get(0)))
+			.diarySummary(toDiarySummaryDto(participant.getDiary()))
 			.scheduleType(participant.getSchedule().getScheduleType())
 			.participantsCount(participant.getSchedule().getParticipantCount())
 			.participantsNames(participant.getSchedule().getParticipantNicknames())

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
@@ -3,6 +3,7 @@ package com.namo.spring.application.external.api.record.converter;
 import com.namo.spring.application.external.api.record.dto.DiaryResponse;
 import com.namo.spring.db.mysql.domains.record.entity.Diary;
 import com.namo.spring.db.mysql.domains.record.entity.DiaryImage;
+import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 
 public class DiaryResponseConverter {
 
@@ -22,6 +23,28 @@ public class DiaryResponseConverter {
 			.orderNumber(image.getImageOrder())
 			.diaryImageId(image.getId())
 			.imageUrl(image.getImageUrl())
+			.build();
+	}
+
+	public static DiaryResponse.DiaryArchiveDto toDiaryArchiveDto(Participant participant) {
+		return DiaryResponse.DiaryArchiveDto.builder()
+			.scheduleDate(participant.getSchedule().getPeriod().getStartDate())
+			.scheduleId(participant.getSchedule().getId())
+			.title(participant.getSchedule().getTitle())
+			.diarySummary(toDiarySummaryDto(participant.getDiaries().get(0)))
+			.scheduleType(participant.getSchedule().getScheduleType())
+			.participantsCount(participant.getSchedule().getParticipantCount())
+			.participantsNames(participant.getSchedule().getParticipantNicknames())
+			.build();
+	}
+
+	private static DiaryResponse.DiarySummaryDto toDiarySummaryDto(Diary diary) {
+		return DiaryResponse.DiarySummaryDto.builder()
+			.diaryId(diary.getId())
+			.content(diary.getContent())
+			.diaryImages(diary.getImages().stream()
+				.map(DiaryResponseConverter::toDiaryImageDto)
+				.toList())
 			.build();
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -34,8 +34,9 @@ public class DiaryResponse {
 	public static class DiaryArchiveDto {
 		private LocalDateTime scheduleDate;
 		private Long scheduleId;
+		private String title;
 		private DiarySummaryDto diarySummary;
-		private boolean isMeetingSchedule;
+		private int scheduleType;
 		private int participantsCount;
 		private String participantsNames;
 	}
@@ -45,9 +46,8 @@ public class DiaryResponse {
 	@AllArgsConstructor
 	public static class DiarySummaryDto {
 		private Long diaryId;
-		private String title;
 		private String content;
-		private DiaryImageDto diaryImage;
+		private List<DiaryImageDto> diaryImages;
 	}
 
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
@@ -34,8 +34,7 @@ public class DiaryManageService {
 	public Diary getParticipantDiary(Participant participant) {
 		if (!participant.isHasDiary())
 			throw new DiaryException(ErrorStatus.NOT_WRITTEN_DIARY_FAILURE);
-		//Todo: 이후 다이어리를 여러 버전으로 저장하는 기획 변경시 최신 버전을 가져오도록 수정 필요 (현재는 첫번째 다이어리만 가져옴) - 2024.8.25
-		return participant.getDiaries().get(0);
+		return participant.getDiary();
 	}
 
 	public void makeDiary(DiaryRequest.CreateDiaryDto request, Participant participant) {

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
@@ -2,7 +2,6 @@ package com.namo.spring.application.external.api.record.usecase;
 
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,8 +45,10 @@ public class DiaryUseCase {
 	}
 
 	@Transactional(readOnly = true)
-	public List<DiaryResponse.DiaryArchiveDto> getDiaryArchiveDto(Long memberId, Pageable pageable) {
-		List<Participant> allMyParticipant = participantManageService.getMyParticipation(memberId, pageable);
+	public List<DiaryResponse.DiaryArchiveDto> getDiaryArchiveDto(Long memberId, int page, String filterType,
+		String keyword) {
+		List<Participant> allMyParticipant = participantManageService.getMyParticipationForArchive(memberId, page,
+			filterType, keyword);
 		return allMyParticipant.stream()
 			.map(DiaryResponseConverter::toDiaryArchiveDto)
 			.toList();

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
@@ -1,5 +1,8 @@
 package com.namo.spring.application.external.api.record.usecase;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,5 +43,13 @@ public class DiaryUseCase {
 			scheduleId);
 		Diary diary = diaryManageService.getParticipantDiary(participant);
 		return DiaryResponseConverter.toDiaryDto(diary);
+	}
+
+	@Transactional(readOnly = true)
+	public List<DiaryResponse.DiaryArchiveDto> getDiaryArchiveDto(Long memberId, Pageable pageable) {
+		List<Participant> allMyParticipant = participantManageService.getMyParticipation(memberId, pageable);
+		return allMyParticipant.stream()
+			.map(DiaryResponseConverter::toDiaryArchiveDto)
+			.toList();
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
@@ -113,7 +113,7 @@ public class ParticipantManageService {
 	}
 
 	public List<Participant> getMyParticipationForArchive(Long memberId, int page, String filterType, String keyword) {
-		Pageable pageable = PageRequest.of(page, 5);
+		Pageable pageable = PageRequest.of(page - 1, 5);
 		if (filterType == null || filterType.isEmpty())
 			return participantService.readParticipantsForDiary(memberId, pageable);
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
@@ -14,6 +14,7 @@ import com.namo.spring.db.mysql.domains.category.entity.Palette;
 import com.namo.spring.db.mysql.domains.category.exception.PaletteException;
 import com.namo.spring.db.mysql.domains.category.type.ColorChip;
 import com.namo.spring.db.mysql.domains.category.type.PaletteEnum;
+import com.namo.spring.db.mysql.domains.record.exception.DiaryException;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.exception.ScheduleException;
@@ -111,8 +112,24 @@ public class ParticipantManageService {
 			.orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE));
 	}
 
-	public List<Participant> getMyParticipationForDiary(Long memberId, int page) {
+	public List<Participant> getMyParticipationForArchive(Long memberId, int page, String filterType, String keyword) {
 		Pageable pageable = PageRequest.of(page, 5);
-		return participantService.readParticipantsForDiary(memberId, pageable);
+		if (filterType == null || filterType.isEmpty())
+			return participantService.readParticipantsForDiary(memberId, pageable);
+
+		switch (filterType) {
+			case "ScheduleName" -> {
+				return participantService.readParticipantByScheduleName(memberId, pageable, keyword);
+			}
+			case "DiaryContent" -> {
+				return participantService.readParticipantByDiaryContent(memberId, pageable, keyword);
+			}
+			case "MemberNickname" -> {
+				return participantService.readParticipantByMember(memberId, pageable, keyword);
+			}
+			default -> {
+				throw new DiaryException(ErrorStatus.NOT_FILTERTYPE_OF_ARCHIVE);
+			}
+		}
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -110,7 +111,8 @@ public class ParticipantManageService {
 			.orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE));
 	}
 
-	public List<Participant> getMyParticipation(Long memberId, Pageable pageable) {
-		return participantService.readParticipants(memberId, pageable);
+	public List<Participant> getMyParticipationForDiary(Long memberId, int page) {
+		Pageable pageable = PageRequest.of(page, 5);
+		return participantService.readParticipantsForDiary(memberId, pageable);
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
@@ -1,5 +1,12 @@
 package com.namo.spring.application.external.api.schedule.service;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
 import com.namo.spring.application.external.api.schedule.dto.ScheduleRequest;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.db.mysql.domains.category.entity.Palette;
@@ -16,91 +23,94 @@ import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 import com.namo.spring.db.mysql.domains.user.exception.MemberException;
 import com.namo.spring.db.mysql.domains.user.service.FriendshipService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ParticipantManageService {
-    private static final Long MEETING_SCHEDULE_OWNER_PALETTE_ID = ColorChip.getMeetingScheduleOwnerPaletteId();
-    private static final long[] PALETTE_IDS = PaletteEnum.getPaletteColorIds();
-    private final ParticipantMaker participantMaker;
-    private final ParticipationActionManager participationActionManager;
-    private final FriendshipService friendshipService;
-    private final ParticipantService participantService;
+	private static final Long MEETING_SCHEDULE_OWNER_PALETTE_ID = ColorChip.getMeetingScheduleOwnerPaletteId();
+	private static final long[] PALETTE_IDS = PaletteEnum.getPaletteColorIds();
+	private final ParticipantMaker participantMaker;
+	private final ParticipationActionManager participationActionManager;
+	private final FriendshipService friendshipService;
+	private final ParticipantService participantService;
 
-    public void createPersonalScheduleParticipant(Member member, Schedule schedule, Long categoryId) {
-        participantMaker.makeScheduleOwner(schedule, member, categoryId, null);
-    }
+	public void createPersonalScheduleParticipant(Member member, Schedule schedule, Long categoryId) {
+		participantMaker.makeScheduleOwner(schedule, member, categoryId, null);
+	}
 
-    public void createMeetingScheduleParticipants(Member owner, Schedule schedule, List<Member> participants) {
-        participantMaker.makeScheduleOwner(schedule, owner, null, MEETING_SCHEDULE_OWNER_PALETTE_ID);
-        schedule.addActiveParticipant(owner.getNickname());
-        participants.forEach(participant -> participantMaker.makeMeetingScheduleParticipant(schedule, participant));
-    }
+	public void createMeetingScheduleParticipants(Member owner, Schedule schedule, List<Member> participants) {
+		participantMaker.makeScheduleOwner(schedule, owner, null, MEETING_SCHEDULE_OWNER_PALETTE_ID);
+		schedule.addActiveParticipant(owner.getNickname());
+		participants.forEach(participant -> participantMaker.makeMeetingScheduleParticipant(schedule, participant));
+	}
 
-    public List<Member> getFriendshipValidatedParticipants(Long ownerId, List<Long> memberIds) {
-        List<Member> friends = friendshipService.readFriendshipsByMemberIdAndFriendIds(ownerId, memberIds).stream()
-                .map(Friendship::getFriend)
-                .collect(Collectors.toList());
-        if (memberIds.size() != friends.size()) {
-            throw new MemberException(ErrorStatus.NOT_FOUND_FRIENDSHIP_FAILURE);
-        }
-        return friends;
-    }
+	public List<Member> getFriendshipValidatedParticipants(Long ownerId, List<Long> memberIds) {
+		List<Member> friends = friendshipService.readFriendshipsByMemberIdAndFriendIds(ownerId, memberIds).stream()
+			.map(Friendship::getFriend)
+			.collect(Collectors.toList());
+		if (memberIds.size() != friends.size()) {
+			throw new MemberException(ErrorStatus.NOT_FOUND_FRIENDSHIP_FAILURE);
+		}
+		return friends;
+	}
 
-    public Participant getValidatedMeetingParticipantWithSchedule(Long memberId, Long scheduleId) {
-        return participantService.readParticipantByScheduleIdAndMemberId(scheduleId, memberId).orElseThrow(
-                () -> new ScheduleException(ErrorStatus.NOT_SCHEDULE_PARTICIPANT));
-    }
+	public Participant getValidatedMeetingParticipantWithSchedule(Long memberId, Long scheduleId) {
+		return participantService.readParticipantByScheduleIdAndMemberId(scheduleId, memberId).orElseThrow(
+			() -> new ScheduleException(ErrorStatus.NOT_SCHEDULE_PARTICIPANT));
+	}
 
-    public void activateParticipant(Long memberId, Long scheduleId) {
-        Participant participant = getValidatedMeetingParticipantWithSchedule(scheduleId, memberId);
-        Long paletteId = selectPaletteColorId(scheduleId);
-        participationActionManager.activateParticipant(participant.getSchedule(), participant, paletteId);
-    }
+	public void activateParticipant(Long memberId, Long scheduleId) {
+		Participant participant = getValidatedMeetingParticipantWithSchedule(scheduleId, memberId);
+		Long paletteId = selectPaletteColorId(scheduleId);
+		participationActionManager.activateParticipant(participant.getSchedule(), participant, paletteId);
+	}
 
-    private Long selectPaletteColorId(Long scheduleId) {
-        List<Long> participantsColors = getMeetingScheduleParticipants(scheduleId, ParticipantStatus.ACTIVE)
-                .stream().map(Participant::getPalette).map(Palette::getId).collect(Collectors.toList());
-        return Arrays.stream(PALETTE_IDS)
-                .filter((color) -> !participantsColors.contains(color))
-                .findFirst()
-                .orElseThrow(() -> new PaletteException(ErrorStatus.NOT_FOUND_COLOR));
-    }
+	private Long selectPaletteColorId(Long scheduleId) {
+		List<Long> participantsColors = getMeetingScheduleParticipants(scheduleId, ParticipantStatus.ACTIVE)
+			.stream().map(Participant::getPalette).map(Palette::getId).collect(Collectors.toList());
+		return Arrays.stream(PALETTE_IDS)
+			.filter((color) -> !participantsColors.contains(color))
+			.findFirst()
+			.orElseThrow(() -> new PaletteException(ErrorStatus.NOT_FOUND_COLOR));
+	}
 
-    public void updateMeetingScheduleParticipants(Long ownerId, Schedule schedule, ScheduleRequest.PatchMeetingScheduleDto dto) {
-        if (!dto.getParticipantsToAdd().isEmpty()) {
-            List<Member> participantsToAdd = getFriendshipValidatedParticipants(ownerId, dto.getParticipantsToAdd());
-            participantsToAdd.forEach(participant -> participantMaker.makeMeetingScheduleParticipant(schedule, participant));
-        }
+	public void updateMeetingScheduleParticipants(Long ownerId, Schedule schedule,
+		ScheduleRequest.PatchMeetingScheduleDto dto) {
+		if (!dto.getParticipantsToAdd().isEmpty()) {
+			List<Member> participantsToAdd = getFriendshipValidatedParticipants(ownerId, dto.getParticipantsToAdd());
+			participantsToAdd.forEach(
+				participant -> participantMaker.makeMeetingScheduleParticipant(schedule, participant));
+		}
 
-        if (!dto.getParticipantsToRemove().isEmpty()) {
-            List<Participant> participantsToRemove = participantService.readParticipantsByIdAndScheduleId(dto.getParticipantsToRemove(), schedule.getId(), ParticipantStatus.ACTIVE);
-            if (participantsToRemove.isEmpty()) {
-                throw new ScheduleException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE);
-            }
-            participationActionManager.removeParticipants(schedule, participantsToRemove);
-        }
-    }
+		if (!dto.getParticipantsToRemove().isEmpty()) {
+			List<Participant> participantsToRemove = participantService.readParticipantsByIdAndScheduleId(
+				dto.getParticipantsToRemove(), schedule.getId(), ParticipantStatus.ACTIVE);
+			if (participantsToRemove.isEmpty()) {
+				throw new ScheduleException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE);
+			}
+			participationActionManager.removeParticipants(schedule, participantsToRemove);
+		}
+	}
 
-    public List<Participant> getMeetingScheduleParticipants(Long scheduleId, ParticipantStatus status) {
-        List<Participant> participants = participantService.readParticipantsByScheduleIdAndStatusAndType(scheduleId, ScheduleType.MEETING, status);
-        if (participants.isEmpty()) {
-            throw new ScheduleException(ErrorStatus.SCHEDULE_PARTICIPANT_IS_EMPTY_ERROR);
-        } else return participants;
-    }
+	public List<Participant> getMeetingScheduleParticipants(Long scheduleId, ParticipantStatus status) {
+		List<Participant> participants = participantService.readParticipantsByScheduleIdAndStatusAndType(scheduleId,
+			ScheduleType.MEETING, status);
+		if (participants.isEmpty()) {
+			throw new ScheduleException(ErrorStatus.SCHEDULE_PARTICIPANT_IS_EMPTY_ERROR);
+		} else
+			return participants;
+	}
 
-    public Participant getScheduleParticipant(Long memberId, Long scheduleId) {
-        return participantService.readParticipants(memberId, scheduleId)
-                .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE));
-    }
+	public Participant getScheduleParticipant(Long memberId, Long scheduleId) {
+		return participantService.readParticipant(memberId, scheduleId)
+			.orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE));
+	}
 
-
+	public List<Participant> getMyParticipation(Long memberId, Pageable pageable) {
+		return participantService.readParticipants(memberId, pageable);
+	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleMaker.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleMaker.java
@@ -1,5 +1,10 @@
 package com.namo.spring.application.external.api.schedule.service;
 
+import static com.namo.spring.application.external.api.schedule.converter.ScheduleConverter.*;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.namo.spring.application.external.api.schedule.dto.ScheduleRequest;
 import com.namo.spring.core.infra.common.aws.s3.FileUtils;
 import com.namo.spring.core.infra.common.constant.FilePath;
@@ -8,35 +13,35 @@ import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.service.ScheduleService;
 import com.namo.spring.db.mysql.domains.schedule.type.Period;
 import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
 
-import static com.namo.spring.application.external.api.schedule.converter.ScheduleConverter.toSchedule;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class ScheduleMaker {
-    private static final int PERSONAL_SCHEDULE_TYPE = ScheduleType.PERSONAL.getValue();
-    private static final int MEETING_SCHEDULE_TYPE = ScheduleType.MEETING.getValue();
+	private static final int PERSONAL_SCHEDULE_TYPE = ScheduleType.PERSONAL.getValue();
+	private static final int MEETING_SCHEDULE_TYPE = ScheduleType.MEETING.getValue();
 
-    private final ScheduleService scheduleService;
-    private final ImageUrlProperties imageUrlProperties;
-    private final FileUtils fileUtils;
+	private final ScheduleService scheduleService;
+	private final ImageUrlProperties imageUrlProperties;
+	private final FileUtils fileUtils;
 
-    public Schedule createPersonalSchedule(ScheduleRequest.PostPersonalScheduleDto dto, Period period) {
-        Schedule schedule = toSchedule(dto.getTitle(), period, dto.getLocation(), PERSONAL_SCHEDULE_TYPE, null, null, null);
-        return scheduleService.createSchedule(schedule);
-    }
+	public Schedule createPersonalSchedule(ScheduleRequest.PostPersonalScheduleDto dto, Period period,
+		String nickname) {
+		Schedule schedule = toSchedule(dto.getTitle(), period, dto.getLocation(), PERSONAL_SCHEDULE_TYPE, null, 1,
+			nickname);
+		return scheduleService.createSchedule(schedule);
+	}
 
-    public Schedule createMeetingSchedule(ScheduleRequest.PostMeetingScheduleDto dto, Period period, MultipartFile image) {
-        String url = imageUrlProperties.getMeeting();
-        if (image != null && !image.isEmpty()) {
-            url = fileUtils.uploadImage(image, FilePath.MEETING_PROFILE_IMG);
-        }
+	public Schedule createMeetingSchedule(ScheduleRequest.PostMeetingScheduleDto dto, Period period,
+		MultipartFile image) {
+		String url = imageUrlProperties.getMeeting();
+		if (image != null && !image.isEmpty()) {
+			url = fileUtils.uploadImage(image, FilePath.MEETING_PROFILE_IMG);
+		}
 
-        Schedule schedule = toSchedule(dto.getTitle(), period, dto.getLocation(), MEETING_SCHEDULE_TYPE, url, 0, "");
-        return scheduleService.createSchedule(schedule);
-    }
+		Schedule schedule = toSchedule(dto.getTitle(), period, dto.getLocation(), MEETING_SCHEDULE_TYPE, url, 0, "");
+		return scheduleService.createSchedule(schedule);
+	}
 
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
@@ -1,5 +1,15 @@
 package com.namo.spring.application.external.api.schedule.service;
 
+import static com.namo.spring.application.external.api.schedule.converter.ScheduleConverter.*;
+import static com.namo.spring.application.external.global.utils.MeetingParticipantValidationUtils.*;
+import static com.namo.spring.application.external.global.utils.SchedulePeriodValidationUtils.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.namo.spring.application.external.api.schedule.dto.ScheduleRequest;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
@@ -8,115 +18,128 @@ import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.exception.ScheduleException;
 import com.namo.spring.db.mysql.domains.schedule.service.ParticipantService;
 import com.namo.spring.db.mysql.domains.schedule.service.ScheduleService;
-import com.namo.spring.db.mysql.domains.schedule.type.*;
+import com.namo.spring.db.mysql.domains.schedule.type.Location;
+import com.namo.spring.db.mysql.domains.schedule.type.ParticipantRole;
+import com.namo.spring.db.mysql.domains.schedule.type.ParticipantStatus;
+import com.namo.spring.db.mysql.domains.schedule.type.Period;
+import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 import com.namo.spring.db.mysql.domains.user.entity.User;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static com.namo.spring.application.external.api.schedule.converter.ScheduleConverter.toLocation;
-import static com.namo.spring.application.external.global.utils.MeetingParticipantValidationUtils.validateExistingAndNewParticipantIds;
-import static com.namo.spring.application.external.global.utils.MeetingParticipantValidationUtils.validateParticipantCount;
-import static com.namo.spring.application.external.global.utils.SchedulePeriodValidationUtils.getValidatedPeriod;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ScheduleManageService {
-    private final ScheduleMaker scheduleMaker;
-    private final ScheduleService scheduleService;
-    private final ParticipantManageService participantManageService;
-    private final ParticipantService participantService;
+	private final ScheduleMaker scheduleMaker;
+	private final ScheduleService scheduleService;
+	private final ParticipantManageService participantManageService;
+	private final ParticipantService participantService;
 
-    public Schedule getMeetingSchedule(Long scheduleId) {
-        Schedule schedule = scheduleService.readSchedule(scheduleId).orElseThrow(() -> new ScheduleException(ErrorStatus.NOT_FOUND_SCHEDULE_FAILURE));
-        if (schedule.getScheduleType() != ScheduleType.MEETING.getValue()) {
-            throw new ScheduleException(ErrorStatus.NOT_MEETING_SCHEDULE);
-        }
-        return schedule;
-    }
+	public Schedule getMeetingSchedule(Long scheduleId) {
+		Schedule schedule = scheduleService.readSchedule(scheduleId)
+			.orElseThrow(() -> new ScheduleException(ErrorStatus.NOT_FOUND_SCHEDULE_FAILURE));
+		if (schedule.getScheduleType() != ScheduleType.MEETING.getValue()) {
+			throw new ScheduleException(ErrorStatus.NOT_MEETING_SCHEDULE);
+		}
+		return schedule;
+	}
 
-    public Schedule createPersonalSchedule(ScheduleRequest.PostPersonalScheduleDto dto, Member member) {
-        Period period = getValidatedPeriod(dto.getPeriod().getStartDate(), dto.getPeriod().getEndDate());
-        Schedule schedule = scheduleMaker.createPersonalSchedule(dto, period);
-        participantManageService.createPersonalScheduleParticipant(member, schedule, dto.getCategoryId());
-        return schedule;
-    }
+	public Schedule createPersonalSchedule(ScheduleRequest.PostPersonalScheduleDto dto, Member member) {
+		Period period = getValidatedPeriod(dto.getPeriod().getStartDate(), dto.getPeriod().getEndDate());
+		Schedule schedule = scheduleMaker.createPersonalSchedule(dto, period, member.getNickname());
+		participantManageService.createPersonalScheduleParticipant(member, schedule, dto.getCategoryId());
+		return schedule;
+	}
 
-    public Schedule createMeetingSchedule(ScheduleRequest.PostMeetingScheduleDto dto, Member owner, MultipartFile image) {
-        validateParticipantCount(dto.getParticipants().size());
-        List<Member> participants = participantManageService.getFriendshipValidatedParticipants(owner.getId(), dto.getParticipants());
-        Period period = getValidatedPeriod(dto.getPeriod().getStartDate(), dto.getPeriod().getEndDate());
-        Schedule schedule = scheduleMaker.createMeetingSchedule(dto, period, image);
-        participantManageService.createMeetingScheduleParticipants(owner, schedule, participants);
-        return schedule;
-    }
+	public Schedule createMeetingSchedule(ScheduleRequest.PostMeetingScheduleDto dto, Member owner,
+		MultipartFile image) {
+		validateParticipantCount(dto.getParticipants().size());
+		List<Member> participants = participantManageService.getFriendshipValidatedParticipants(owner.getId(),
+			dto.getParticipants());
+		Period period = getValidatedPeriod(dto.getPeriod().getStartDate(), dto.getPeriod().getEndDate());
+		Schedule schedule = scheduleMaker.createMeetingSchedule(dto, period, image);
+		participantManageService.createMeetingScheduleParticipants(owner, schedule, participants);
+		return schedule;
+	}
 
-    public List<Schedule> getMeetingScheduleItems(Long memberId) {
-        List<Long> scheduleIds = participantService.readScheduleParticipantItemsByScheduleIds(memberId).stream()
-                .map(Participant::getSchedule)
-                .map(Schedule::getId)
-                .collect(Collectors.toList());
-        return scheduleService.readSchedulesById(scheduleIds);
-    }
+	public List<Schedule> getMeetingScheduleItems(Long memberId) {
+		List<Long> scheduleIds = participantService.readScheduleParticipantItemsByScheduleIds(memberId).stream()
+			.map(Participant::getSchedule)
+			.map(Schedule::getId)
+			.collect(Collectors.toList());
+		return scheduleService.readSchedulesById(scheduleIds);
+	}
 
-    public List<ScheduleParticipantQuery> getMonthlyMembersSchedules(List<Long> memberIds, Period period, Long memberId) {
-        validateParticipantCount(memberIds.size());
-        List<Long> members = participantManageService.getFriendshipValidatedParticipants(memberId, memberIds).stream().map(Member::getId).collect(Collectors.toList());
-        members.add(memberId);
-        return participantService.readParticipantsWithScheduleAndUsers(members, period.getStartDate(), period.getEndDate());
-    }
+	public List<ScheduleParticipantQuery> getMonthlyMembersSchedules(List<Long> memberIds, Period period,
+		Long memberId) {
+		validateParticipantCount(memberIds.size());
+		List<Long> members = participantManageService.getFriendshipValidatedParticipants(memberId, memberIds)
+			.stream()
+			.map(Member::getId)
+			.collect(Collectors.toList());
+		members.add(memberId);
+		return participantService.readParticipantsWithScheduleAndUsers(members, period.getStartDate(),
+			period.getEndDate());
+	}
 
-    public List<ScheduleParticipantQuery> getMonthlyMeetingParticipantSchedules(Schedule schedule, Period period, Long memberId) {
-        checkParticipantExists(schedule, memberId);
-        List<Participant> participants = participantManageService.getMeetingScheduleParticipants(schedule.getId(), ParticipantStatus.ACTIVE);
-        List<Long> members = participants.stream().map(Participant::getUser).map(User::getId).collect(Collectors.toList());
+	public List<ScheduleParticipantQuery> getMonthlyMeetingParticipantSchedules(Schedule schedule, Period period,
+		Long memberId) {
+		checkParticipantExists(schedule, memberId);
+		List<Participant> participants = participantManageService.getMeetingScheduleParticipants(schedule.getId(),
+			ParticipantStatus.ACTIVE);
+		List<Long> members = participants.stream()
+			.map(Participant::getUser)
+			.map(User::getId)
+			.collect(Collectors.toList());
 
-        return participantService.readParticipantsWithScheduleAndUsers(members, period.getStartDate(), period.getEndDate());
-    }
+		return participantService.readParticipantsWithScheduleAndUsers(members, period.getStartDate(),
+			period.getEndDate());
+	}
 
-    private void checkParticipantExists(Schedule schedule, Long memberId) {
-        if (!participantService.existsByScheduleIdAndMemberId(schedule.getId(), memberId)) {
-            throw new ScheduleException(ErrorStatus.NOT_SCHEDULE_PARTICIPANT);
-        }
-    }
+	private void checkParticipantExists(Schedule schedule, Long memberId) {
+		if (!participantService.existsByScheduleIdAndMemberId(schedule.getId(), memberId)) {
+			throw new ScheduleException(ErrorStatus.NOT_SCHEDULE_PARTICIPANT);
+		}
+	}
 
-    public List<Participant> getMeetingScheduleParticipants(Schedule schedule, Long memberId) {
-        checkParticipantExists(schedule, memberId);
-        return participantService.readParticipantsByScheduleIdAndStatusAndType(schedule.getId(), ScheduleType.MEETING, null);
-    }
+	public List<Participant> getMeetingScheduleParticipants(Schedule schedule, Long memberId) {
+		checkParticipantExists(schedule, memberId);
+		return participantService.readParticipantsByScheduleIdAndStatusAndType(schedule.getId(), ScheduleType.MEETING,
+			null);
+	}
 
-    public void updateMeetingSchedule(ScheduleRequest.PatchMeetingScheduleDto dto, Schedule schedule, Long memberId) {
-        Participant ownerParticipant = participantManageService.getValidatedMeetingParticipantWithSchedule(memberId, schedule.getId());
-        checkParticipantIsOwner(ownerParticipant);
-        updateScheduleContent(dto.getTitle(), dto.getLocation(), dto.getPeriod(), schedule);
-        // 기존의 인원과, 초대될 & 삭제될 member  검증
-        if (!dto.getParticipantsToAdd().isEmpty() || !dto.getParticipantsToRemove().isEmpty()) {
-            List<Long> participantIds = participantService.readParticipantsByScheduleId(schedule.getId()).stream()
-                    .filter(participant -> participant.getIsOwner() == ParticipantRole.NON_OWNER.getValue())
-                    .map(Participant::getMember)
-                    .map(Member::getId)
-                    .collect(Collectors.toList());
-            validateParticipantCount(participantIds.size() + dto.getParticipantsToAdd().size() - dto.getParticipantsToRemove().size());
-            validateExistingAndNewParticipantIds(participantIds, dto.getParticipantsToAdd());
-            participantManageService.updateMeetingScheduleParticipants(memberId, schedule, dto);
-        }
-    }
+	public void updateMeetingSchedule(ScheduleRequest.PatchMeetingScheduleDto dto, Schedule schedule, Long memberId) {
+		Participant ownerParticipant = participantManageService.getValidatedMeetingParticipantWithSchedule(memberId,
+			schedule.getId());
+		checkParticipantIsOwner(ownerParticipant);
+		updateScheduleContent(dto.getTitle(), dto.getLocation(), dto.getPeriod(), schedule);
+		// 기존의 인원과, 초대될 & 삭제될 member  검증
+		if (!dto.getParticipantsToAdd().isEmpty() || !dto.getParticipantsToRemove().isEmpty()) {
+			List<Long> participantIds = participantService.readParticipantsByScheduleId(schedule.getId()).stream()
+				.filter(participant -> participant.getIsOwner() == ParticipantRole.NON_OWNER.getValue())
+				.map(Participant::getMember)
+				.map(Member::getId)
+				.collect(Collectors.toList());
+			validateParticipantCount(
+				participantIds.size() + dto.getParticipantsToAdd().size() - dto.getParticipantsToRemove().size());
+			validateExistingAndNewParticipantIds(participantIds, dto.getParticipantsToAdd());
+			participantManageService.updateMeetingScheduleParticipants(memberId, schedule, dto);
+		}
+	}
 
-    private void updateScheduleContent(String title, ScheduleRequest.LocationDto locationDto, ScheduleRequest.PeriodDto periodDto, Schedule schedule) {
-        Period period = getValidatedPeriod(periodDto.getStartDate(), periodDto.getEndDate());
-        Location location = locationDto != null ? toLocation(locationDto) : null;
-        schedule.updateContent(title, period, location);
-    }
+	private void updateScheduleContent(String title, ScheduleRequest.LocationDto locationDto,
+		ScheduleRequest.PeriodDto periodDto, Schedule schedule) {
+		Period period = getValidatedPeriod(periodDto.getStartDate(), periodDto.getEndDate());
+		Location location = locationDto != null ? toLocation(locationDto) : null;
+		schedule.updateContent(title, period, location);
+	}
 
-    private void checkParticipantIsOwner(Participant participant) {
-        if (participant.getIsOwner() != ParticipantRole.OWNER.getValue()) {
-            throw new ScheduleException(ErrorStatus.NOT_SCHEDULE_OWNER);
-        }
-    }
+	private void checkParticipantIsOwner(Participant participant) {
+		if (participant.getIsOwner() != ParticipantRole.OWNER.getValue()) {
+			throw new ScheduleException(ErrorStatus.NOT_SCHEDULE_OWNER);
+		}
+	}
 }

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -1,172 +1,174 @@
 package com.namo.spring.core.common.code.status;
 
+import org.springframework.http.HttpStatus;
+
 import com.namo.spring.core.common.code.BaseErrorCode;
 import com.namo.spring.core.common.response.ResponseDto;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
 
-    /**
-     * Common Error & Global Error
-     */
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "올바르지 않은 요청입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증과정에서 오류가 발생하였습니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "금지된 요청입니다."),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않은 Http Method 입니다."),
+	/**
+	 * Common Error & Global Error
+	 */
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+	METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "올바르지 않은 요청입니다."),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증과정에서 오류가 발생하였습니다."),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "금지된 요청입니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않은 Http Method 입니다."),
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다."),
 
-    /**
-     * 400: Bad Request
-     */
-    MAKE_PUBLIC_KEY_FAILURE(HttpStatus.BAD_REQUEST, "애플 퍼블릭 키를 생성하는데 실패하였습니다"),
-    APPLE_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "애플 identityToken이 잘못되었습니다."),
-    USER_POST_ERROR(HttpStatus.BAD_REQUEST, "email나 name이 비어있어 유저를 생성할 수 없습니다."),
-    MEETING_INVALID_PARTICIPANT_NUMBER(HttpStatus.BAD_REQUEST, "모임의 인원은 2명 이상, 10명 이하 입니다."),
-    MEETING_DUPLICATE_PARTICIPANT(HttpStatus.BAD_REQUEST, "중복되는 참여자입니다."),
-    ALREADY_WRITTEN_DIARY_FAILURE(HttpStatus.BAD_REQUEST, "이미 일기를 작성하였습니다."),
-    NOT_WRITTEN_DIARY_FAILURE(HttpStatus.BAD_REQUEST, "일기를 작성하지 않았습니다."),
-    NOT_MY_DIARY_FAILURE(HttpStatus.BAD_REQUEST, "해당 일기에 대한 권한이 없습니다."),
-    NOT_SCHEDULE_OWNER(HttpStatus.BAD_REQUEST, "해당 모임 일정의 생성자가 아닙니다."),
-    NOT_SCHEDULE_PARTICIPANT(HttpStatus.BAD_REQUEST, "해당 일정의 참석자가 아닙니다."),
-    NOT_MEETING_SCHEDULE(HttpStatus.BAD_REQUEST, "모임 일정이 아닙니다."),
+	/**
+	 * 400: Bad Request
+	 */
+	MAKE_PUBLIC_KEY_FAILURE(HttpStatus.BAD_REQUEST, "애플 퍼블릭 키를 생성하는데 실패하였습니다"),
+	APPLE_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "애플 identityToken이 잘못되었습니다."),
+	USER_POST_ERROR(HttpStatus.BAD_REQUEST, "email나 name이 비어있어 유저를 생성할 수 없습니다."),
+	MEETING_INVALID_PARTICIPANT_NUMBER(HttpStatus.BAD_REQUEST, "모임의 인원은 2명 이상, 10명 이하 입니다."),
+	MEETING_DUPLICATE_PARTICIPANT(HttpStatus.BAD_REQUEST, "중복되는 참여자입니다."),
+	ALREADY_WRITTEN_DIARY_FAILURE(HttpStatus.BAD_REQUEST, "이미 일기를 작성하였습니다."),
+	NOT_WRITTEN_DIARY_FAILURE(HttpStatus.BAD_REQUEST, "일기를 작성하지 않았습니다."),
+	NOT_MY_DIARY_FAILURE(HttpStatus.BAD_REQUEST, "해당 일기에 대한 권한이 없습니다."),
+	NOT_SCHEDULE_OWNER(HttpStatus.BAD_REQUEST, "해당 모임 일정의 생성자가 아닙니다."),
+	NOT_SCHEDULE_PARTICIPANT(HttpStatus.BAD_REQUEST, "해당 일정의 참석자가 아닙니다."),
+	NOT_MEETING_SCHEDULE(HttpStatus.BAD_REQUEST, "모임 일정이 아닙니다."),
 
-    /**
-     * 401 : 소셜 로그인 오류
-     */
-    SOCIAL_LOGIN_FAILURE(HttpStatus.UNAUTHORIZED, "소셜 로그인에 실패하였습니다."),
-    SOCIAL_WITHDRAWAL_FAILURE(HttpStatus.UNAUTHORIZED, "소셜 로그인 회원탈퇴에 실패하였습니다."),
-    KAKAO_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "카카오 accessToken이 잘못되었습니다"),
-    NAVER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "네이버 accessToken이 잘못되었습니다"),
-    APPLE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "애플 authorization code가 잘못되었습니다."),
-    FORBIDDEN_ACCESS_TOKEN(HttpStatus.FORBIDDEN, "해당 토큰에는 엑세스 권한이 없습니다."),
-    EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "사용기간이 만료된 토큰입니다."),
+	/**
+	 * 401 : 소셜 로그인 오류
+	 */
+	SOCIAL_LOGIN_FAILURE(HttpStatus.UNAUTHORIZED, "소셜 로그인에 실패하였습니다."),
+	SOCIAL_WITHDRAWAL_FAILURE(HttpStatus.UNAUTHORIZED, "소셜 로그인 회원탈퇴에 실패하였습니다."),
+	KAKAO_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "카카오 accessToken이 잘못되었습니다"),
+	NAVER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "네이버 accessToken이 잘못되었습니다"),
+	APPLE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "애플 authorization code가 잘못되었습니다."),
+	FORBIDDEN_ACCESS_TOKEN(HttpStatus.FORBIDDEN, "해당 토큰에는 엑세스 권한이 없습니다."),
+	EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "사용기간이 만료된 토큰입니다."),
 
-    /**
-     * 403 : local Access Token 오류
-     */
-    EMPTY_ACCESS_KEY(HttpStatus.FORBIDDEN, "AccessToken 이 비어있습니다."),
-    LOGOUT_ERROR(HttpStatus.FORBIDDEN, "로그 아웃된 사용자입니다."),
-    EXPIRATION_TOKEN(HttpStatus.FORBIDDEN, "Token 이 만료되었습니다."),
-    TAKEN_AWAY_TOKEN(HttpStatus.FORBIDDEN, "탈취당한 토큰입니다. 다시 로그인 해주세요."),
-    WITHOUT_OWNER_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "소유자가 아닌 RefreshToken 입니다."),
-    EXPIRATION_ACCESS_TOKEN(HttpStatus.FORBIDDEN, "Access token 이 만료되었습니다."),
-    EXPIRATION_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "RefreshToken 이 만료되었습니다."),
-    KAKAO_FORBIDDEN(HttpStatus.FORBIDDEN, "카카오 권한 오류"),
-    NAVER_FORBIDDEN(HttpStatus.FORBIDDEN, "네이버 권한 오류"),
-    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "비정상적인 토큰입니다."),
-    TAMPERED_TOKEN(HttpStatus.UNAUTHORIZED, "서명이 조작된 토큰입니다."),
-    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 코튼입니다."),
+	/**
+	 * 403 : local Access Token 오류
+	 */
+	EMPTY_ACCESS_KEY(HttpStatus.FORBIDDEN, "AccessToken 이 비어있습니다."),
+	LOGOUT_ERROR(HttpStatus.FORBIDDEN, "로그 아웃된 사용자입니다."),
+	EXPIRATION_TOKEN(HttpStatus.FORBIDDEN, "Token 이 만료되었습니다."),
+	TAKEN_AWAY_TOKEN(HttpStatus.FORBIDDEN, "탈취당한 토큰입니다. 다시 로그인 해주세요."),
+	WITHOUT_OWNER_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "소유자가 아닌 RefreshToken 입니다."),
+	EXPIRATION_ACCESS_TOKEN(HttpStatus.FORBIDDEN, "Access token 이 만료되었습니다."),
+	EXPIRATION_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "RefreshToken 이 만료되었습니다."),
+	KAKAO_FORBIDDEN(HttpStatus.FORBIDDEN, "카카오 권한 오류"),
+	NAVER_FORBIDDEN(HttpStatus.FORBIDDEN, "네이버 권한 오류"),
+	MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "비정상적인 토큰입니다."),
+	TAMPERED_TOKEN(HttpStatus.UNAUTHORIZED, "서명이 조작된 토큰입니다."),
+	UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 코튼입니다."),
 
-    /**
-     * 404 : NOT FOUND 오류
-     */
-    NOT_FOUND_USER_FAILURE(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
-    NOT_FOUND_SCHEDULE_FAILURE(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다."),
-    NOT_FOUND_PARTICIPANT_FAILURE(HttpStatus.NOT_FOUND, "일정의 참여자를 찾을 수 없습니다."),
-    NOT_FOUND_CATEGORY_FAILURE(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
-    NOT_FOUND_PALETTE_FAILURE(HttpStatus.NOT_FOUND, "팔레트를 찾을 수 없습니다."),
-    NOT_FOUND_DIARY_FAILURE(HttpStatus.NOT_FOUND, "다이어리를 찾을 수 없습니다."),
-    NOT_FOUND_GROUP_DIARY_FAILURE(HttpStatus.NOT_FOUND, "모임 메모 장소를 찾을 수 없습니다."),
-    NOT_FOUND_GROUP_FAILURE(HttpStatus.NOT_FOUND, "그룹을 찾을 수 없습니다."),
-    NOT_FOUND_GROUP_AND_USER_FAILURE(HttpStatus.NOT_FOUND, "모임 일정의 참여자가 아닙니다."),
-    NOT_FOUND_GROUP_SCHEDULE_AND_USER_FAILURE(HttpStatus.NOT_FOUND, "그룹 스케줄 구성원이 아닙니다."),
-    NOT_FOUND_GROUP_MEMO_FAILURE(HttpStatus.NOT_FOUND, "모임 메모를 찾을 수 없습니다."),
-    NOT_FOUND_GROUP_MEMO_LOCATION_FAILURE(HttpStatus.NOT_FOUND, "모임 활동을 찾을 수 없습니다."),
-    NOT_FOUND_ACTIVITY_IMG_FAILURE(HttpStatus.NOT_FOUND, "모임 활동 이미지를 찾을 수 없습니다."),
-    NOT_FOUND_COLOR(HttpStatus.NOT_FOUND, "색깔을 찾을 수 없습니다."),
-    NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
-    NOT_FOUND_FRIENDSHIP_FAILURE(HttpStatus.NOT_FOUND, "친구인 유저를 찾을 수 없습니다."),
+	/**
+	 * 404 : NOT FOUND 오류
+	 */
+	NOT_FOUND_USER_FAILURE(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+	NOT_FOUND_SCHEDULE_FAILURE(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다."),
+	NOT_FOUND_PARTICIPANT_FAILURE(HttpStatus.NOT_FOUND, "일정의 참여자를 찾을 수 없습니다."),
+	NOT_FOUND_CATEGORY_FAILURE(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+	NOT_FOUND_PALETTE_FAILURE(HttpStatus.NOT_FOUND, "팔레트를 찾을 수 없습니다."),
+	NOT_FOUND_DIARY_FAILURE(HttpStatus.NOT_FOUND, "다이어리를 찾을 수 없습니다."),
+	NOT_FOUND_GROUP_DIARY_FAILURE(HttpStatus.NOT_FOUND, "모임 메모 장소를 찾을 수 없습니다."),
+	NOT_FOUND_GROUP_FAILURE(HttpStatus.NOT_FOUND, "그룹을 찾을 수 없습니다."),
+	NOT_FOUND_GROUP_AND_USER_FAILURE(HttpStatus.NOT_FOUND, "모임 일정의 참여자가 아닙니다."),
+	NOT_FOUND_GROUP_SCHEDULE_AND_USER_FAILURE(HttpStatus.NOT_FOUND, "그룹 스케줄 구성원이 아닙니다."),
+	NOT_FOUND_GROUP_MEMO_FAILURE(HttpStatus.NOT_FOUND, "모임 메모를 찾을 수 없습니다."),
+	NOT_FOUND_GROUP_MEMO_LOCATION_FAILURE(HttpStatus.NOT_FOUND, "모임 활동을 찾을 수 없습니다."),
+	NOT_FOUND_ACTIVITY_IMG_FAILURE(HttpStatus.NOT_FOUND, "모임 활동 이미지를 찾을 수 없습니다."),
+	NOT_FOUND_COLOR(HttpStatus.NOT_FOUND, "색깔을 찾을 수 없습니다."),
+	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
+	NOT_FOUND_FRIENDSHIP_FAILURE(HttpStatus.NOT_FOUND, "친구인 유저를 찾을 수 없습니다."),
 
-    /**
-     * 404 : 예외 상황 에러
-     */
-    NOT_DELETE_BASE_CATEGORY_FAILURE(HttpStatus.NOT_FOUND, "일정 및 모임 카테고리는 삭제 될 수 없습니다."),
-    NOT_CHANGE_SPECIFIED_NAME_FAILURE(HttpStatus.NOT_FOUND, "일정 및 모임은 기본 카테고리로 지정된 이름입니다."),
-    NOT_INCLUDE_OWNER_IN_REQUEST(HttpStatus.NOT_FOUND, "모임 생성자는 참가자 목록에 포함될 수 없습니다."),
-    NOT_CHECK_TERM_ERROR(HttpStatus.NOT_FOUND, "약관에 무조건 동의 해야합니다."),
-    GROUP_MEMO_IS_FULL_ERROR(HttpStatus.NOT_FOUND, "모임 메모가 가득 차 있습니다."),
-    NOT_INCLUDE_GROUP_USER(HttpStatus.NOT_FOUND, "모임 안에 포함되어 있지 않은 유저입니다."),
-    EMPTY_USERS_FAILURE(HttpStatus.NOT_FOUND, "모임 일정에 참여글 유저가 없습니다."),
-    NOT_HAS_GROUP_CATEGORIES_USERS(HttpStatus.NOT_FOUND, "유저들에 대한 모임의 카테고리가 없습니다."),
-    INVALID_DATE(HttpStatus.NOT_FOUND, "시작 날짜가 종료 날짜 이전 이어야 합니다."),
-    INVALID_ALARM(HttpStatus.NOT_FOUND, "알림 시간이 유효하지 않습니다."),
-    INVALID_MEETING_PARTICIPANT_COUNT(HttpStatus.NOT_FOUND, "모임 일정은 최소 1명, 최대 9명까지 초대 가능합니다."),
-    DUPLICATE_MEETING_PARTICIPANT(HttpStatus.NOT_FOUND, "중복되는 참여자입니다."),
-    SCHEDULE_PARTICIPANT_IS_EMPTY_ERROR(HttpStatus.NOT_FOUND, "모임 일정의 참여자가 없습니다."),
+	/**
+	 * 404 : 예외 상황 에러
+	 */
+	NOT_DELETE_BASE_CATEGORY_FAILURE(HttpStatus.NOT_FOUND, "일정 및 모임 카테고리는 삭제 될 수 없습니다."),
+	NOT_CHANGE_SPECIFIED_NAME_FAILURE(HttpStatus.NOT_FOUND, "일정 및 모임은 기본 카테고리로 지정된 이름입니다."),
+	NOT_INCLUDE_OWNER_IN_REQUEST(HttpStatus.NOT_FOUND, "모임 생성자는 참가자 목록에 포함될 수 없습니다."),
+	NOT_CHECK_TERM_ERROR(HttpStatus.NOT_FOUND, "약관에 무조건 동의 해야합니다."),
+	GROUP_MEMO_IS_FULL_ERROR(HttpStatus.NOT_FOUND, "모임 메모가 가득 차 있습니다."),
+	NOT_INCLUDE_GROUP_USER(HttpStatus.NOT_FOUND, "모임 안에 포함되어 있지 않은 유저입니다."),
+	EMPTY_USERS_FAILURE(HttpStatus.NOT_FOUND, "모임 일정에 참여글 유저가 없습니다."),
+	NOT_HAS_GROUP_CATEGORIES_USERS(HttpStatus.NOT_FOUND, "유저들에 대한 모임의 카테고리가 없습니다."),
+	INVALID_DATE(HttpStatus.NOT_FOUND, "시작 날짜가 종료 날짜 이전 이어야 합니다."),
+	INVALID_ALARM(HttpStatus.NOT_FOUND, "알림 시간이 유효하지 않습니다."),
+	INVALID_MEETING_PARTICIPANT_COUNT(HttpStatus.NOT_FOUND, "모임 일정은 최소 1명, 최대 9명까지 초대 가능합니다."),
+	DUPLICATE_MEETING_PARTICIPANT(HttpStatus.NOT_FOUND, "중복되는 참여자입니다."),
+	SCHEDULE_PARTICIPANT_IS_EMPTY_ERROR(HttpStatus.NOT_FOUND, "모임 일정의 참여자가 없습니다."),
 
+	/**
+	 * 404 : 중복 에러
+	 */
+	DIARY_EXISTS_FAILURE(HttpStatus.NOT_FOUND, "이미 존재하는 다이어리 입니다."),
+	DUPLICATE_PARTICIPATE_FAILURE(HttpStatus.NOT_FOUND, "이미 가입한 그룹입니다."),
+	DUPLICATE_GROUP_MEMO_FAILURE(HttpStatus.NOT_FOUND, "이미 모임 메모가 생성되어 있습니다."),
+	DUPLICATE_EMAIL_FAILURE(HttpStatus.NOT_FOUND, "이미 해당 소셜 이메일이 가입되어 있습니다."),
 
-    /**
-     * 404 : 중복 에러
-     */
-    DIARY_EXISTS_FAILURE(HttpStatus.NOT_FOUND, "이미 존재하는 다이어리 입니다."),
-    DUPLICATE_PARTICIPATE_FAILURE(HttpStatus.NOT_FOUND, "이미 가입한 그룹입니다."),
-    DUPLICATE_GROUP_MEMO_FAILURE(HttpStatus.NOT_FOUND, "이미 모임 메모가 생성되어 있습니다."),
-    DUPLICATE_EMAIL_FAILURE(HttpStatus.NOT_FOUND, "이미 해당 소셜 이메일이 가입되어 있습니다."),
+	/**
+	 * 404 : 오용 오류
+	 */
+	NOT_USERS_CATEGORY(HttpStatus.NOT_FOUND, "해당 유저의 카테고리가 아닙니다."),
+	NOT_USERS_IN_GROUP(HttpStatus.NOT_FOUND, "유저가 그룹에 포함되어 있지 않습니다."),
+	NOT_IMAGE_IN_DIARY(HttpStatus.NOT_FOUND, "이미지가 다이어리에 포함되어 있지 않습니다."),
+	NOT_FILTERTYPE_OF_ARCHIVE(HttpStatus.NOT_FOUND, "올바른 필터 타입이 아닙니다"),
 
-    /**
-     * 404 : 오용 오류
-     */
-    NOT_USERS_CATEGORY(HttpStatus.NOT_FOUND, "해당 유저의 카테고리가 아닙니다."),
-    NOT_USERS_IN_GROUP(HttpStatus.NOT_FOUND, "유저가 그룹에 포함되어 있지 않습니다."),
-    NOT_IMAGE_IN_DIARY(HttpStatus.NOT_FOUND, "이미지가 다이어리에 포함되어 있지 않습니다."),
+	/**
+	 * 404 : 인프라 에러
+	 */
+	FILE_NAME_EXCEPTION(HttpStatus.NOT_FOUND, "파일 확장자가 잘못되었습니다."),
+	S3_UPLOAD_FAILURE(HttpStatus.NOT_FOUND, "파일 업로드 과정에서 오류가 발생하였습니다."),
+	S3_DELETE_FAILURE(HttpStatus.NOT_FOUND, "파일 삭제 과정에서 오류가 발생하였습니다."),
+	NAVER_NOT_FOUND(HttpStatus.NOT_FOUND, "[네이버] 검색 결과가 없습니다"),
 
-    /**
-     * 404 : 인프라 에러
-     */
-    FILE_NAME_EXCEPTION(HttpStatus.NOT_FOUND, "파일 확장자가 잘못되었습니다."),
-    S3_UPLOAD_FAILURE(HttpStatus.NOT_FOUND, "파일 업로드 과정에서 오류가 발생하였습니다."),
-    S3_DELETE_FAILURE(HttpStatus.NOT_FOUND, "파일 삭제 과정에서 오류가 발생하였습니다."),
-    NAVER_NOT_FOUND(HttpStatus.NOT_FOUND, "[네이버] 검색 결과가 없습니다"),
+	/**
+	 * 404 : IllegalArgumentException
+	 */
+	NOT_NULL_FAILURE(HttpStatus.NOT_FOUND, "널 혹은 비어 있는 값을 카테고리 값으로 넣지 말아주세요,"),
+	INVALID_FORMAT_FAILURE(HttpStatus.NOT_FOUND, "유효한 날짜 값을 입력해주세요"),
 
-    /**
-     * 404 : IllegalArgumentException
-     */
-    NOT_NULL_FAILURE(HttpStatus.NOT_FOUND, "널 혹은 비어 있는 값을 카테고리 값으로 넣지 말아주세요,"),
-    INVALID_FORMAT_FAILURE(HttpStatus.NOT_FOUND, "유효한 날짜 값을 입력해주세요"),
+	/**
+	 * 404 : 서버 에러
+	 */
+	INTERNET_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류"),
+	JPA_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "jpa, sql 상에서 오류가 발생했습니다."),
+	KAKAO_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버 오류"),
+	KAKAO_BAD_GATEWAY(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 시스템 오류"),
+	KAKAO_SERVICE_UNAVAILABLE(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서비스 점검 중"),
+	FEIGN_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "feign 서버 에러");
 
-    /**
-     * 404 : 서버 에러
-     */
-    INTERNET_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류"),
-    JPA_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "jpa, sql 상에서 오류가 발생했습니다."),
-    KAKAO_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버 오류"),
-    KAKAO_BAD_GATEWAY(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 시스템 오류"),
-    KAKAO_SERVICE_UNAVAILABLE(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서비스 점검 중"),
-    FEIGN_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "feign 서버 에러");
+	private final HttpStatus code;
+	private final String message;
 
-    private final HttpStatus code;
-    private final String message;
+	public int getCode() {
+		return code.value();
+	}
 
-    public int getCode() {
-        return code.value();
-    }
+	public HttpStatus getHttpStatus() {
+		return code;
+	}
 
-    public HttpStatus getHttpStatus() {
-        return code;
-    }
+	@Override
+	public ResponseDto.ErrorReasonDto getReason() {
+		return ResponseDto.ErrorReasonDto.builder()
+			.isSuccess(false)
+			.code(getCode())
+			.message(message)
+			.build();
+	}
 
-    @Override
-    public ResponseDto.ErrorReasonDto getReason() {
-        return ResponseDto.ErrorReasonDto.builder()
-                .isSuccess(false)
-                .code(getCode())
-                .message(message)
-                .build();
-    }
-
-    @Override
-    public ResponseDto.ErrorReasonDto getReasonHttpStatus() {
-        return ResponseDto.ErrorReasonDto.builder()
-                .status(this.code)
-                .isSuccess(false)
-                .code(getCode())
-                .message(message)
-                .build();
-    }
+	@Override
+	public ResponseDto.ErrorReasonDto getReasonHttpStatus() {
+		return ResponseDto.ErrorReasonDto.builder()
+			.status(this.code)
+			.isSuccess(false)
+			.code(getCode())
+			.message(message)
+			.build();
+	}
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/record/entity/Diary.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/record/entity/Diary.java
@@ -11,8 +11,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PostPersist;
 import jakarta.persistence.PostRemove;
 
@@ -40,7 +40,7 @@ public class Diary extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@OneToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "participant_id", nullable = false)
 	private Participant participant;
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
@@ -1,5 +1,22 @@
 package com.namo.spring.db.mysql.domains.schedule.entity;
 
+import java.util.Objects;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+
+import org.hibernate.annotations.DynamicInsert;
+
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 import com.namo.spring.db.mysql.domains.category.entity.Category;
 import com.namo.spring.db.mysql.domains.category.entity.Palette;
@@ -8,15 +25,11 @@ import com.namo.spring.db.mysql.domains.schedule.type.ParticipantStatus;
 import com.namo.spring.db.mysql.domains.user.entity.Anonymous;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 import com.namo.spring.db.mysql.domains.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.DynamicInsert;
-
-import java.util.List;
-import java.util.Objects;
 
 @Getter
 @Entity
@@ -24,93 +37,93 @@ import java.util.Objects;
 @DynamicInsert
 public class Participant extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    // 0: 참여자, 1: 주최자
-    @Column(nullable = false, columnDefinition = "TINYINT")
-    private int isOwner;
+	// 0: 참여자, 1: 주최자
+	@Column(nullable = false, columnDefinition = "TINYINT")
+	private int isOwner;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "anonymous_id")
-    private Anonymous anonymous;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "anonymous_id")
+	private Anonymous anonymous;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "schedule_id", nullable = false)
-    private Schedule schedule;
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "schedule_id", nullable = false)
+	private Schedule schedule;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private ParticipantStatus status;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private ParticipantStatus status;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = true)
-    @JoinColumn(name = "category_id", nullable = true)
-    private Category category;
+	@ManyToOne(fetch = FetchType.LAZY, optional = true)
+	@JoinColumn(name = "category_id", nullable = true)
+	private Category category;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = true)
-    @JoinColumn(name = "palette_id", nullable = true)
-    private Palette palette;
+	@ManyToOne(fetch = FetchType.LAZY, optional = true)
+	@JoinColumn(name = "palette_id", nullable = true)
+	private Palette palette;
 
-    private boolean hasDiary;
+	private boolean hasDiary;
 
-    @OneToMany(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Diary> diaries;
+	@OneToOne(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+	private Diary diary;
 
-    @Builder
-    public Participant(int isOwner, User user, Schedule schedule, ParticipantStatus status, Category category,
-                       Palette palette) {
-        this.isOwner = Objects.requireNonNull(isOwner, "isOwner은 null일 수 없습니다.");
-        this.member = user instanceof Member ? (Member) user : null;
-        this.anonymous = user instanceof Anonymous ? (Anonymous) user : null;
-        this.schedule = Objects.requireNonNull(schedule, "schedule은 null일 수 없습니다.");
-        this.status = Objects.requireNonNull(status, "status는 null일 수 없습니다.");
-        this.category = category;
-        this.palette = palette;
-        this.hasDiary = false;
-    }
+	@Builder
+	public Participant(int isOwner, User user, Schedule schedule, ParticipantStatus status, Category category,
+		Palette palette) {
+		this.isOwner = Objects.requireNonNull(isOwner, "isOwner은 null일 수 없습니다.");
+		this.member = user instanceof Member ? (Member)user : null;
+		this.anonymous = user instanceof Anonymous ? (Anonymous)user : null;
+		this.schedule = Objects.requireNonNull(schedule, "schedule은 null일 수 없습니다.");
+		this.status = Objects.requireNonNull(status, "status는 null일 수 없습니다.");
+		this.category = category;
+		this.palette = palette;
+		this.hasDiary = false;
+	}
 
-    public static Participant of(int isOwner, User user, Schedule schedule, ParticipantStatus status, Category category,
-                                 Palette palette) {
-        return Participant.builder()
-                .isOwner(isOwner)
-                .user(user)
-                .schedule(schedule)
-                .status(status)
-                .category(category)
-                .palette(palette)
-                .build();
-    }
+	public static Participant of(int isOwner, User user, Schedule schedule, ParticipantStatus status, Category category,
+		Palette palette) {
+		return Participant.builder()
+			.isOwner(isOwner)
+			.user(user)
+			.schedule(schedule)
+			.status(status)
+			.category(category)
+			.palette(palette)
+			.build();
+	}
 
-    public User getUser() {
-        if (this.member != null) {
-            return this.member;
-        } else if (this.anonymous != null) {
-            return this.anonymous;
-        }
-        return null;
-    }
+	public User getUser() {
+		if (this.member != null) {
+			return this.member;
+		} else if (this.anonymous != null) {
+			return this.anonymous;
+		}
+		return null;
+	}
 
-    public void activateStatus(Category category, Palette palette) {
-        this.status = ParticipantStatus.ACTIVE;
-        this.category = category;
-        this.palette = palette;
-    }
+	public void activateStatus(Category category, Palette palette) {
+		this.status = ParticipantStatus.ACTIVE;
+		this.category = category;
+		this.palette = palette;
+	}
 
-    public void inactiveStatus() {
-        this.status = ParticipantStatus.INACTIVE;
-    }
+	public void inactiveStatus() {
+		this.status = ParticipantStatus.INACTIVE;
+	}
 
-    public void diaryCreated() {
-        this.hasDiary = true;
-    }
+	public void diaryCreated() {
+		this.hasDiary = true;
+	}
 
-    public void diaryDeleted() {
-        this.hasDiary = false;
-    }
+	public void diaryDeleted() {
+		this.hasDiary = false;
+	}
 
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
@@ -1,21 +1,31 @@
 package com.namo.spring.db.mysql.domains.schedule.entity;
 
-import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
-import com.namo.spring.db.mysql.domains.schedule.type.Location;
-import com.namo.spring.db.mysql.domains.schedule.type.Period;
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
+import com.namo.spring.db.mysql.domains.schedule.type.Location;
+import com.namo.spring.db.mysql.domains.schedule.type.Period;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
@@ -23,118 +33,117 @@ import java.util.List;
 @DynamicInsert
 public class Schedule extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(nullable = false)
+	private Long id;
 
-    @JdbcTypeCode(SqlTypes.VARCHAR)
-    @Column(nullable = false, length = 50)
-    private String title;
+	@JdbcTypeCode(SqlTypes.VARCHAR)
+	@Column(nullable = false, length = 50)
+	private String title;
 
-    @Embedded
-    private Period period;
+	@Embedded
+	private Period period;
 
-    @Embedded
-    private Location location;
+	@Embedded
+	private Location location;
 
-    // 0: 개인, 1: 그룹
-    @Column(nullable = false, columnDefinition = "TINYINT")
-    private int scheduleType;
+	// 0: 개인, 1: 그룹
+	@Column(nullable = false, columnDefinition = "TINYINT")
+	private int scheduleType;
 
-    @JdbcTypeCode(SqlTypes.VARCHAR)
-    private String imageUrl;
+	@JdbcTypeCode(SqlTypes.VARCHAR)
+	private String imageUrl;
 
-    @Column(nullable = true)
-    private Integer participantCount;
+	private Integer participantCount;
 
-    @Column(nullable = true)
-    private String participantNicknames;
+	private String participantNicknames;
 
-    @Column(nullable = true)
-    private String invitationUrl;
+	private String invitationUrl;
 
-    @OneToMany(mappedBy = "schedule", fetch = FetchType.LAZY)
-    private List<Participant> participantList = new ArrayList<>();
+	@OneToMany(mappedBy = "schedule", fetch = FetchType.LAZY)
+	private List<Participant> participantList = new ArrayList<>();
 
-    @Builder
-    public Schedule(String title, Period period, Location location, int scheduleType, String imageUrl, Integer participantCount, String participantNicknames) {
-        if (!StringUtils.hasText(title))
-            throw new IllegalArgumentException("title은 null이거나 빈 문자열일 수 없습니다.");
-        this.title = title;
-        this.period = period;
-        this.location = location;
-        this.scheduleType = scheduleType;
-        this.imageUrl = imageUrl;
-        this.participantCount = participantCount;
-        this.participantNicknames = participantNicknames;
-    }
+	@Builder
+	public Schedule(String title, Period period, Location location, int scheduleType, String imageUrl,
+		Integer participantCount, String participantNicknames) {
+		if (!StringUtils.hasText(title))
+			throw new IllegalArgumentException("title은 null이거나 빈 문자열일 수 없습니다.");
+		this.title = title;
+		this.period = period;
+		this.location = location;
+		this.scheduleType = scheduleType;
+		this.imageUrl = imageUrl;
+		this.participantCount = participantCount;
+		this.participantNicknames = participantNicknames;
+	}
 
-    public static Schedule of(String title, Period period, Location location, int scheduleType, String imageUrl, Integer participantCount, String participantNicknames) {
-        return Schedule.builder()
-                .title(title)
-                .period(period)
-                .location(location)
-                .scheduleType(scheduleType)
-                .imageUrl(imageUrl)
-                .participantCount(participantCount)
-                .participantNicknames(participantNicknames)
-                .build();
-    }
+	public static Schedule of(String title, Period period, Location location, int scheduleType, String imageUrl,
+		Integer participantCount, String participantNicknames) {
+		return Schedule.builder()
+			.title(title)
+			.period(period)
+			.location(location)
+			.scheduleType(scheduleType)
+			.imageUrl(imageUrl)
+			.participantCount(participantCount)
+			.participantNicknames(participantNicknames)
+			.build();
+	}
 
-    public void updateContent(String title, Period period, Location location) {
-        this.title = title;
-        this.period = period;
-        if (location != null) {
-            this.location = location;
-        }
-    }
+	public void updateContent(String title, Period period, Location location) {
+		this.title = title;
+		this.period = period;
+		if (location != null) {
+			this.location = location;
+		}
+	}
 
-    public void addActiveParticipant(String nickname) {
-        if (!StringUtils.hasText(nickname))
-            throw new IllegalArgumentException("nickname은 null이거나 빈 문자열일 수 없습니다.");
-        if (this.participantNicknames == null || this.participantNicknames == "") {
-            this.participantNicknames = nickname;
-        } else {
-            this.participantNicknames += ", " + nickname;
-        }
-        if (this.participantCount == null) {
-            this.participantCount = 1;
-        } else {
-            this.participantCount++;
-        }
-    }
+	public void addActiveParticipant(String nickname) {
+		if (!StringUtils.hasText(nickname))
+			throw new IllegalArgumentException("nickname은 null이거나 빈 문자열일 수 없습니다.");
+		if (this.participantNicknames == null || this.participantNicknames == "") {
+			this.participantNicknames = nickname;
+		} else {
+			this.participantNicknames += ", " + nickname;
+		}
+		if (this.participantCount == null) {
+			this.participantCount = 1;
+		} else {
+			this.participantCount++;
+		}
+	}
 
-    public void updateParticipant(String oldNickname, String newNickname) {
-        if (!StringUtils.hasText(oldNickname) || !StringUtils.hasText(newNickname))
-            throw new IllegalArgumentException("nickname은 null이거나 빈 문자열일 수 없습니다.");
-        if (this.participantNicknames != null) {
-            List<String> nicknames = new ArrayList<>(Arrays.asList(this.participantNicknames.split(", ")));
-            int index = nicknames.indexOf(oldNickname);
-            if (index != -1) {
-                nicknames.set(index, newNickname);
-                this.participantNicknames = String.join(", ", nicknames);
-            }
-        }
-    }
+	public void updateParticipant(String oldNickname, String newNickname) {
+		if (!StringUtils.hasText(oldNickname) || !StringUtils.hasText(newNickname))
+			throw new IllegalArgumentException("nickname은 null이거나 빈 문자열일 수 없습니다.");
+		if (this.participantNicknames != null) {
+			List<String> nicknames = new ArrayList<>(Arrays.asList(this.participantNicknames.split(", ")));
+			int index = nicknames.indexOf(oldNickname);
+			if (index != -1) {
+				nicknames.set(index, newNickname);
+				this.participantNicknames = String.join(", ", nicknames);
+			}
+		}
+	}
 
-    public void removeParticipants(List<String> nicknamesToRemove) {
-        if (nicknamesToRemove == null || nicknamesToRemove.isEmpty()) {
-            throw new IllegalArgumentException("삭제할 닉네임 목록이 비어있거나 null일 수 없습니다.");
-        }
+	public void removeParticipants(List<String> nicknamesToRemove) {
+		if (nicknamesToRemove == null || nicknamesToRemove.isEmpty()) {
+			throw new IllegalArgumentException("삭제할 닉네임 목록이 비어있거나 null일 수 없습니다.");
+		}
 
-        List<String> currentNicknames = new ArrayList<>(Arrays.asList(this.participantNicknames.split(", ")));
+		List<String> currentNicknames = new ArrayList<>(Arrays.asList(this.participantNicknames.split(", ")));
 
-        for (String nicknameToRemove : nicknamesToRemove) {
-            currentNicknames.remove(nicknameToRemove); // 첫 번째 일치하는 닉네임만 제거
-        }
+		for (String nicknameToRemove : nicknamesToRemove) {
+			currentNicknames.remove(nicknameToRemove); // 첫 번째 일치하는 닉네임만 제거
+		}
 
-        this.participantNicknames = String.join(", ", currentNicknames);
-        this.participantCount = currentNicknames.size();
-    }
+		this.participantNicknames = String.join(", ", currentNicknames);
+		this.participantCount = currentNicknames.size();
+	}
 
-    public void updateInvitationUrl(String invitationUrl) {
-        this.invitationUrl = invitationUrl;
-    }
+	public void updateInvitationUrl(String invitationUrl) {
+		this.invitationUrl = invitationUrl;
+	}
 
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -60,7 +60,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
 	@Query("SELECT p "
 		+ "FROM Participant p "
-		+ "WHERE p.hasDiary == true and p.member.id == :memberId "
+		+ "WHERE p.hasDiary = true and p.member.id = :memberId "
 		+ "order by p.schedule.period.startDate desc ")
 	List<Participant> findAllByMemberIdAndHasDiary(Long memberId, Pageable pageable);
 
@@ -70,4 +70,15 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 		+ "ORDER BY p.schedule.period.startDate DESC")
 	List<Participant> findAllByScheduleTitleAndHasDiary(Long memberId, String keyword, Pageable pageable);
 
+	@Query("SELECT p "
+		+ "FROM Participant p "
+		+ "WHERE p.hasDiary = true AND p.member.id = :memberId AND p.diary.content LIKE %:keyword% "
+		+ "ORDER BY p.schedule.period.startDate DESC")
+	List<Participant> findAllByDiaryContentAndHasDiary(Long memberId, String keyword, Pageable pageable);
+
+	@Query("SELECT p "
+		+ "FROM Participant p "
+		+ "WHERE p.hasDiary = true AND p.member.id = :memberId AND p.schedule.participantNicknames LIKE %:keyword% "
+		+ "ORDER BY p.schedule.period.startDate DESC")
+	List<Participant> findAllByMemberAndHasDiary(Long memberId, String keyword, Pageable pageable);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -1,58 +1,62 @@
 package com.namo.spring.db.mysql.domains.schedule.repository;
 
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
-import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
-import com.namo.spring.db.mysql.domains.schedule.type.ParticipantStatus;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
+import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
+import com.namo.spring.db.mysql.domains.schedule.type.ParticipantStatus;
+
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
-    List<Participant> findAllByScheduleId(Long scheduleId);
+	List<Participant> findAllByScheduleId(Long scheduleId);
 
-    @Query("SELECT p FROM Participant p JOIN p.schedule s JOIN p.member m WHERE p.member.id = :memberId AND p.status = 'ACTIVE' AND s.scheduleType = :scheduleType")
-    List<Participant> findParticipantsByMemberAndScheduleType(Long memberId, int scheduleType);
+	@Query("SELECT p FROM Participant p JOIN p.schedule s JOIN p.member m WHERE p.member.id = :memberId AND p.status = 'ACTIVE' AND s.scheduleType = :scheduleType")
+	List<Participant> findParticipantsByMemberAndScheduleType(Long memberId, int scheduleType);
 
-    boolean existsByScheduleIdAndMemberId(Long scheduleId, Long memberId);
+	boolean existsByScheduleIdAndMemberId(Long scheduleId, Long memberId);
 
-    @Query("SELECT p FROM Participant p JOIN FETCH p.schedule s LEFT JOIN FETCH p.palette " +
-            "WHERE s.id = :scheduleId AND s.scheduleType = :scheduleType " +
-            "AND (:status IS NULL OR p.status = :status)")
-    List<Participant> findParticipantsByScheduleIdAndStatusAndType(Long scheduleId, int scheduleType, ParticipantStatus status);
+	@Query("SELECT p FROM Participant p JOIN FETCH p.schedule s LEFT JOIN FETCH p.palette " +
+		"WHERE s.id = :scheduleId AND s.scheduleType = :scheduleType " +
+		"AND (:status IS NULL OR p.status = :status)")
+	List<Participant> findParticipantsByScheduleIdAndStatusAndType(Long scheduleId, int scheduleType,
+		ParticipantStatus status);
 
-    @Query("SELECT p FROM Participant p JOIN FETCH p.schedule s WHERE s.id = :scheduleId AND p.member.id = :memberId")
-    Optional<Participant> findParticipantByScheduleIdAndMemberId(Long scheduleId, Long memberId);
+	@Query("SELECT p FROM Participant p JOIN FETCH p.schedule s WHERE s.id = :scheduleId AND p.member.id = :memberId")
+	Optional<Participant> findParticipantByScheduleIdAndMemberId(Long scheduleId, Long memberId);
 
-    @Query("SELECT p " +
-            "FROM Participant p " +
-            "JOIN p.schedule s " +
-            "LEFT JOIN FETCH p.member m " +
-            "LEFT JOIN FETCH p.anonymous a " +
-            "WHERE p.id in :ids AND s.id = :scheduleId AND p.status = :status")
-    List<Participant> findParticipantByIdAndScheduleId(List<Long> ids, Long scheduleId, ParticipantStatus status);
+	@Query("SELECT p " +
+		"FROM Participant p " +
+		"JOIN p.schedule s " +
+		"LEFT JOIN FETCH p.member m " +
+		"LEFT JOIN FETCH p.anonymous a " +
+		"WHERE p.id in :ids AND s.id = :scheduleId AND p.status = :status")
+	List<Participant> findParticipantByIdAndScheduleId(List<Long> ids, Long scheduleId, ParticipantStatus status);
 
-    @Query("SELECT DISTINCT new com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery(" +
-            "p.id, p.palette.id, m.id, m.nickname, s" +
-            ") FROM Participant p " +
-            "JOIN p.schedule s " +
-            "LEFT JOIN p.member m " +
-            "WHERE m.id IN :memberIds " +
-            "AND p.status = 'ACTIVE' " +
-            "AND (s.period.startDate <= :endDate " +
-            "AND s.period.endDate >= :startDate) " +
-            "ORDER BY s.period.startDate ASC")
-    List<ScheduleParticipantQuery> findParticipantsWithUserAndSchedule(
-            List<Long> memberIds,
-            LocalDateTime startDate,
-            LocalDateTime endDate
-    );
+	@Query("SELECT DISTINCT new com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery(" +
+		"p.id, p.palette.id, m.id, m.nickname, s" +
+		") FROM Participant p " +
+		"JOIN p.schedule s " +
+		"LEFT JOIN p.member m " +
+		"WHERE m.id IN :memberIds " +
+		"AND p.status = 'ACTIVE' " +
+		"AND (s.period.startDate <= :endDate " +
+		"AND s.period.endDate >= :startDate) " +
+		"ORDER BY s.period.startDate ASC")
+	List<ScheduleParticipantQuery> findParticipantsWithUserAndSchedule(
+		List<Long> memberIds,
+		LocalDateTime startDate,
+		LocalDateTime endDate
+	);
 
-    void deleteByIdIn(List<Long> id);
+	void deleteByIdIn(List<Long> id);
 
-    Optional<Participant> findParticipantByMemberIdAndScheduleId(Long memberId, Long scheduleId);
+	Optional<Participant> findParticipantByMemberIdAndScheduleId(Long memberId, Long scheduleId);
 
+	List<Participant> findAllByMemberId(Long memberId, Pageable pageable);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -63,4 +63,11 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 		+ "WHERE p.hasDiary == true and p.member.id == :memberId "
 		+ "order by p.schedule.period.startDate desc ")
 	List<Participant> findAllByMemberIdAndHasDiary(Long memberId, Pageable pageable);
+
+	@Query("SELECT p "
+		+ "FROM Participant p "
+		+ "WHERE p.hasDiary = true AND p.member.id = :memberId AND p.schedule.title LIKE %:keyword% "
+		+ "ORDER BY p.schedule.period.startDate DESC")
+	List<Participant> findAllByScheduleTitleAndHasDiary(Long memberId, String keyword, Pageable pageable);
+
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -58,5 +58,9 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
 	Optional<Participant> findParticipantByMemberIdAndScheduleId(Long memberId, Long scheduleId);
 
-	List<Participant> findAllByMemberId(Long memberId, Pageable pageable);
+	@Query("SELECT p "
+		+ "FROM Participant p "
+		+ "WHERE p.hasDiary == true and p.member.id == :memberId "
+		+ "order by p.schedule.period.startDate desc ")
+	List<Participant> findAllByMemberIdAndHasDiary(Long memberId, Pageable pageable);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
@@ -87,4 +87,12 @@ public class ParticipantService {
 	public List<Participant> readParticipantByScheduleName(Long memberId, Pageable pageable, String keyword) {
 		return participantRepository.findAllByScheduleTitleAndHasDiary(memberId, keyword, pageable);
 	}
+
+	public List<Participant> readParticipantByDiaryContent(Long memberId, Pageable pageable, String keyword) {
+		return participantRepository.findAllByDiaryContentAndHasDiary(memberId, keyword, pageable);
+	}
+
+	public List<Participant> readParticipantByMember(Long memberId, Pageable pageable, String keyword) {
+		return participantRepository.findAllByMemberAndHasDiary(memberId, keyword, pageable);
+	}
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
@@ -80,8 +80,7 @@ public class ParticipantService {
 		return participantRepository.findParticipantByMemberIdAndScheduleId(memberId, scheduleId);
 	}
 
-	public List<Participant> readParticipants(Long memberId, Pageable pageable) {
-		return participantRepository.findAllByMemberId(memberId, pageable);
+	public List<Participant> readParticipantsForDiary(Long memberId, Pageable pageable) {
+		return participantRepository.findAllByMemberIdAndHasDiary(memberId, pageable);
 	}
-
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
@@ -83,4 +83,8 @@ public class ParticipantService {
 	public List<Participant> readParticipantsForDiary(Long memberId, Pageable pageable) {
 		return participantRepository.findAllByMemberIdAndHasDiary(memberId, pageable);
 	}
+
+	public List<Participant> readParticipantByScheduleName(Long memberId, Pageable pageable, String keyword) {
+		return participantRepository.findAllByScheduleTitleAndHasDiary(memberId, keyword, pageable);
+	}
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
@@ -1,77 +1,87 @@
 package com.namo.spring.db.mysql.domains.schedule.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.namo.spring.core.common.annotation.DomainService;
 import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.repository.ParticipantRepository;
 import com.namo.spring.db.mysql.domains.schedule.type.ParticipantStatus;
 import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
-import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
 public class ParticipantService {
-    private final ParticipantRepository participantRepository;
+	private final ParticipantRepository participantRepository;
 
-    @Transactional
-    public Participant createParticipant(Participant participant) {
-        return participantRepository.save(participant);
-    }
+	@Transactional
+	public Participant createParticipant(Participant participant) {
+		return participantRepository.save(participant);
+	}
 
-    @Transactional(readOnly = true)
-    public Optional<Participant> readParticipant(Long id) {
-        return participantRepository.findById(id);
-    }
+	@Transactional(readOnly = true)
+	public Optional<Participant> readParticipant(Long id) {
+		return participantRepository.findById(id);
+	}
 
-    @Transactional(readOnly = true)
-    public Optional<Participant> readParticipantByScheduleIdAndMemberId(Long scheduleId, Long memberId) {
-        return participantRepository.findParticipantByScheduleIdAndMemberId(scheduleId, memberId);
-    }
+	@Transactional(readOnly = true)
+	public Optional<Participant> readParticipantByScheduleIdAndMemberId(Long scheduleId, Long memberId) {
+		return participantRepository.findParticipantByScheduleIdAndMemberId(scheduleId, memberId);
+	}
 
-    public List<Participant> readParticipantsByScheduleId(Long scheduleId) {
-        return participantRepository.findAllByScheduleId(scheduleId);
-    }
+	public List<Participant> readParticipantsByScheduleId(Long scheduleId) {
+		return participantRepository.findAllByScheduleId(scheduleId);
+	}
 
-    @Transactional(readOnly = true)
-    public List<Participant> readParticipantsByIdAndScheduleId(List<Long> participantIds, Long scheduleId, ParticipantStatus status) {
-        return participantRepository.findParticipantByIdAndScheduleId(participantIds, scheduleId, status);
-    }
+	@Transactional(readOnly = true)
+	public List<Participant> readParticipantsByIdAndScheduleId(List<Long> participantIds, Long scheduleId,
+		ParticipantStatus status) {
+		return participantRepository.findParticipantByIdAndScheduleId(participantIds, scheduleId, status);
+	}
 
-    @Transactional(readOnly = true)
-    public List<Participant> readScheduleParticipantItemsByScheduleIds(Long memberId) {
-        return participantRepository.findParticipantsByMemberAndScheduleType(memberId, ScheduleType.MEETING.getValue());
-    }
+	@Transactional(readOnly = true)
+	public List<Participant> readScheduleParticipantItemsByScheduleIds(Long memberId) {
+		return participantRepository.findParticipantsByMemberAndScheduleType(memberId, ScheduleType.MEETING.getValue());
+	}
 
-    @Transactional(readOnly = true)
-    public boolean existsByScheduleIdAndMemberId(Long scheduleId, Long memberId) {
-        return participantRepository.existsByScheduleIdAndMemberId(scheduleId, memberId);
-    }
+	@Transactional(readOnly = true)
+	public boolean existsByScheduleIdAndMemberId(Long scheduleId, Long memberId) {
+		return participantRepository.existsByScheduleIdAndMemberId(scheduleId, memberId);
+	}
 
-    @Transactional(readOnly = true)
-    public List<ScheduleParticipantQuery> readParticipantsWithScheduleAndUsers(List<Long> memberIds, LocalDateTime startDate, LocalDateTime endDate) {
-        return participantRepository.findParticipantsWithUserAndSchedule(memberIds, startDate, endDate);
-    }
+	@Transactional(readOnly = true)
+	public List<ScheduleParticipantQuery> readParticipantsWithScheduleAndUsers(List<Long> memberIds,
+		LocalDateTime startDate, LocalDateTime endDate) {
+		return participantRepository.findParticipantsWithUserAndSchedule(memberIds, startDate, endDate);
+	}
 
-    @Transactional(readOnly = true)
-    public List<Participant> readParticipantsByScheduleIdAndStatusAndType(Long scheduleId, ScheduleType type, ParticipantStatus status) {
-        return participantRepository.findParticipantsByScheduleIdAndStatusAndType(scheduleId, type.getValue(), status);
-    }
+	@Transactional(readOnly = true)
+	public List<Participant> readParticipantsByScheduleIdAndStatusAndType(Long scheduleId, ScheduleType type,
+		ParticipantStatus status) {
+		return participantRepository.findParticipantsByScheduleIdAndStatusAndType(scheduleId, type.getValue(), status);
+	}
 
-    public void deleteParticipant(Long id) {
-        participantRepository.deleteById(id);
-    }
+	public void deleteParticipant(Long id) {
+		participantRepository.deleteById(id);
+	}
 
-    public void deleteByIdIn(List<Long> Ids) {
-        participantRepository.deleteByIdIn(Ids);
-    }
+	public void deleteByIdIn(List<Long> Ids) {
+		participantRepository.deleteByIdIn(Ids);
+	}
 
-    public Optional<Participant> readParticipants(Long memberId, Long scheduleId) {
-        return participantRepository.findParticipantByMemberIdAndScheduleId(memberId, scheduleId);
-    }
+	public Optional<Participant> readParticipant(Long memberId, Long scheduleId) {
+		return participantRepository.findParticipantByMemberIdAndScheduleId(memberId, scheduleId);
+	}
+
+	public List<Participant> readParticipants(Long memberId, Pageable pageable) {
+		return participantRepository.findAllByMemberId(memberId, pageable);
+	}
 
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

### 주요 변경사항
- diary<->participant 연관관계가 다대일 -> 일대일로 수정되었습니다.
- 개인 일정 생성시 participantCount:1 ,  participantNicknames: 본인 닉네임 초기값으로 셋팅하도록 변경되었습니다.

### 구현부 변경사항
- 기존 보관함 조회에서 filter와 keyword를 사용한 조회로 변경되었습니다.
  - 일치 하지 않는 filter Name입력시 에러처리 구현
- page는 0부터 시작하며 5개씩 조회됩니다. 

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #280
