### PR TITLE
[Feature/283] 일기 보관함 캘린더 조회 관련 API 구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
@@ -1,5 +1,17 @@
 package com.namo.spring.application.external.api.record.Controller;
 
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.namo.spring.application.external.api.record.dto.DiaryRequest;
 import com.namo.spring.application.external.api.record.dto.DiaryResponse;
 import com.namo.spring.application.external.api.record.usecase.DiaryUseCase;
@@ -7,14 +19,12 @@ import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCo
 import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.response.ResponseDto;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "기록(일기)", description = "기록(일기:diary) 관련 API")
 @RestController
@@ -22,66 +32,79 @@ import java.util.List;
 @RequestMapping("/api/v2/diaries")
 public class DiaryController {
 
-    private final DiaryUseCase diaryUseCase;
+	private final DiaryUseCase diaryUseCase;
 
-    @Operation(summary = "기록 생성", description = "기록(일기) 생성 API 입니다. 개인, 단체 일정 모두 공통으로 사용합니다.")
-    @ApiErrorCodes(value = {
-            ErrorStatus.ALREADY_WRITTEN_DIARY_FAILURE,
-            ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE,
-    })
-    @PostMapping("")
-    public ResponseDto<String> createDiary(
-            @AuthenticationPrincipal SecurityUserDetails memberInfo,
-            @RequestBody DiaryRequest.CreateDiaryDto request
-    ) {
-        diaryUseCase.createDiary(memberInfo, request);
-        return ResponseDto.onSuccess("기록 생성 성공");
-    }
+	@Operation(summary = "기록 생성", description = "기록(일기) 생성 API 입니다. 개인, 단체 일정 모두 공통으로 사용합니다.")
+	@ApiErrorCodes(value = {
+		ErrorStatus.ALREADY_WRITTEN_DIARY_FAILURE,
+		ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE,
+	})
+	@PostMapping("")
+	public ResponseDto<String> createDiary(
+		@AuthenticationPrincipal SecurityUserDetails memberInfo,
+		@RequestBody DiaryRequest.CreateDiaryDto request
+	) {
+		diaryUseCase.createDiary(memberInfo, request);
+		return ResponseDto.onSuccess("기록 생성 성공");
+	}
 
-    @PatchMapping("/{diaryId}")
-    @Operation(summary = "기록 수정", description = "기록(일기) 수정 API 입니다. 모든 이미지 URL을 새로 보내주어야 합니다.")
-    @ApiErrorCodes(value = {
-            ErrorStatus.NOT_FOUND_DIARY_FAILURE,
-            ErrorStatus.NOT_MY_DIARY_FAILURE,
-    })
-    public ResponseDto<String> updateDiary(
-            @AuthenticationPrincipal SecurityUserDetails memberInfo,
-            @PathVariable Long diaryId,
-            @RequestBody DiaryRequest.UpdateDiaryDto request
-    ) {
-        diaryUseCase.updateDiary(diaryId, memberInfo, request);
-        return ResponseDto.onSuccess("기록 수정 성공");
-    }
+	@PatchMapping("/{diaryId}")
+	@Operation(summary = "기록 수정", description = "기록(일기) 수정 API 입니다. 모든 이미지 URL을 새로 보내주어야 합니다.")
+	@ApiErrorCodes(value = {
+		ErrorStatus.NOT_FOUND_DIARY_FAILURE,
+		ErrorStatus.NOT_MY_DIARY_FAILURE,
+	})
+	public ResponseDto<String> updateDiary(
+		@AuthenticationPrincipal SecurityUserDetails memberInfo,
+		@PathVariable Long diaryId,
+		@RequestBody DiaryRequest.UpdateDiaryDto request
+	) {
+		diaryUseCase.updateDiary(diaryId, memberInfo, request);
+		return ResponseDto.onSuccess("기록 수정 성공");
+	}
 
-    @Operation(summary = "기록 조회", description = "기록(일기) 단일 상세 조회 API 입니다. 개인, 단체 일정 모두 공통으로 사용합니다.")
-    @ApiErrorCodes(value = {
-            ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE,
-            ErrorStatus.NOT_WRITTEN_DIARY_FAILURE,
-    })
-    @GetMapping("/{scheduleId}")
-    public ResponseDto<DiaryResponse.DiaryDto> getDiary(
-            @AuthenticationPrincipal SecurityUserDetails memberInfo,
-            @PathVariable Long scheduleId
-    ) {
-        return ResponseDto.onSuccess(diaryUseCase
-                .getScheduleDiary(scheduleId, memberInfo));
-    }
+	@Operation(summary = "기록 조회", description = "기록(일기) 단일 상세 조회 API 입니다. 개인, 단체 일정 모두 공통으로 사용합니다.")
+	@ApiErrorCodes(value = {
+		ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE,
+		ErrorStatus.NOT_WRITTEN_DIARY_FAILURE,
+	})
+	@GetMapping("/{scheduleId}")
+	public ResponseDto<DiaryResponse.DiaryDto> getDiary(
+		@AuthenticationPrincipal SecurityUserDetails memberInfo,
+		@PathVariable Long scheduleId
+	) {
+		return ResponseDto.onSuccess(diaryUseCase
+			.getScheduleDiary(scheduleId, memberInfo));
+	}
 
-    @Operation(summary = "기록 보관함 조회", description = "기록(일기) 보관함 조회 API 입니다. ")
-    @ApiErrorCodes(value = {
-            ErrorStatus.NOT_FILTERTYPE_OF_ARCHIVE,
-    })
-    @GetMapping("/archive")
-    public ResponseDto<List<DiaryResponse.DiaryArchiveDto>> getDiaryArchive(
-            @AuthenticationPrincipal SecurityUserDetails memberInfo,
-            @Parameter(description = "ScheduleName(스케쥴 이름 조회) || DiaryContent(일기 내용 조회) || MemberNickname (참여자 조회)")
-            @RequestParam(required = false) String filterType,
-            @Parameter(description = "각 필터에 맞는 검색 단어를 입력하시면 됩니다.")
-            @RequestParam(required = false) String keyword,
-            @Parameter(description = "1 부터 시작하는 page입니다. 5개의 일기씩 내림차순 조회됩니다. ")
-            @RequestParam int page
-    ) {
-        return ResponseDto.onSuccess(diaryUseCase
-                .getDiaryArchiveDto(memberInfo.getUserId(), page, filterType, keyword));
-    }
+	@Operation(summary = "기록 보관함 조회", description = "기록(일기) 보관함 조회 API 입니다. ")
+	@ApiErrorCodes(value = {
+		ErrorStatus.NOT_FILTERTYPE_OF_ARCHIVE,
+	})
+	@GetMapping("/archive")
+	public ResponseDto<List<DiaryResponse.DiaryArchiveDto>> getDiaryArchive(
+		@AuthenticationPrincipal SecurityUserDetails memberInfo,
+		@Parameter(description = "ScheduleName(스케쥴 이름 조회) || DiaryContent(일기 내용 조회) || MemberNickname (참여자 조회)")
+		@RequestParam(required = false) String filterType,
+		@Parameter(description = "각 필터에 맞는 검색 단어를 입력하시면 됩니다.")
+		@RequestParam(required = false) String keyword,
+		@Parameter(description = "1 부터 시작하는 page입니다. 5개의 일기씩 내림차순 조회됩니다. ")
+		@RequestParam int page
+	) {
+		return ResponseDto.onSuccess(diaryUseCase
+			.getDiaryArchiveDto(memberInfo.getUserId(), page, filterType, keyword));
+	}
+
+	@Operation(summary = "기록 캘린더 조회", description = "기록이 존재하는 달력 확인 API 입니다. 월별로 일기가 존재하는 날짜를 반환합니다. ")
+	@GetMapping("/calendar")
+	public ResponseDto<DiaryResponse.DiaryExistDateDto> getArchiveCalender(
+		@AuthenticationPrincipal SecurityUserDetails memberInfo,
+		@Parameter(description = "조회할 달력의 년도입니다.", example = "2024")
+		@RequestParam int year,
+		@Parameter(description = "조회할 달력의 월입니다.", example = "9")
+		@RequestParam int month
+	) {
+		return ResponseDto.onSuccess(diaryUseCase
+			.getExistDiaryDate(memberInfo.getUserId(), year, month));
+	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
@@ -123,7 +123,7 @@ public class DiaryController {
 	@ApiErrorCodes(value = {
 		ErrorStatus.INVALID_FORMAT_FAILURE,
 	})
-	@GetMapping("/{date}")
+	@GetMapping("/date/{date}")
 	public ResponseDto<List<DiaryResponse.DayOfDiaryDto>> getDayDiary(
 		@AuthenticationPrincipal SecurityUserDetails memberInfo,
 		@Parameter(description = "조회할 날짜입니다.", example = "2024-09-01")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
@@ -1,6 +1,5 @@
 package com.namo.spring.application.external.api.record.Controller;
 
-import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
@@ -23,6 +22,7 @@ import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCo
 import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.response.ResponseDto;
+import com.namo.spring.db.mysql.domains.record.exception.DiaryException;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -100,6 +100,9 @@ public class DiaryController {
 	}
 
 	@Operation(summary = "기록 캘린더 조회", description = "기록이 존재하는 달력 확인 API 입니다. 월별로 일기가 존재하는 날짜를 반환합니다. ")
+	@ApiErrorCodes(value = {
+		ErrorStatus.INVALID_FORMAT_FAILURE,
+	})
 	@GetMapping("/calendar/{yearMonth}")
 	public ResponseDto<DiaryResponse.DiaryExistDateDto> getArchiveCalender(
 		@AuthenticationPrincipal SecurityUserDetails memberInfo,
@@ -112,11 +115,14 @@ public class DiaryController {
 				.getExistDiaryDate(memberInfo.getUserId(), requestedYearMonth));
 
 		} catch (DateTimeParseException e) {
-			throw new DateTimeException("형식에 맞지 않는 일자입니다.");
+			throw new DiaryException(ErrorStatus.INVALID_FORMAT_FAILURE);
 		}
 	}
 
 	@Operation(summary = "날짜별 기록 정보 조회", description = "날짜 별 기록이 존재하는 스케줄 정보가 확인됩니다. 기록 캘린더 조회에서 요일을 선택하여 상세 정보를 확인할 때 사용하시면 됩니다.")
+	@ApiErrorCodes(value = {
+		ErrorStatus.INVALID_FORMAT_FAILURE,
+	})
 	@GetMapping("/{date}")
 	public ResponseDto<List<DiaryResponse.DayOfDiaryDto>> getDayDiary(
 		@AuthenticationPrincipal SecurityUserDetails memberInfo,
@@ -127,7 +133,7 @@ public class DiaryController {
 			return ResponseDto.onSuccess(diaryUseCase
 				.getDayDiaryList(memberInfo.getUserId(), requestedDate));
 		} catch (DateTimeParseException e) {
-			throw new DateTimeException("형식에 맞지 않는 일자입니다.");
+			throw new DiaryException(ErrorStatus.INVALID_FORMAT_FAILURE);
 		}
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
@@ -1,12 +1,15 @@
 package com.namo.spring.application.external.api.record.converter;
 
+import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.namo.spring.application.external.api.record.dto.DiaryResponse;
+import com.namo.spring.db.mysql.domains.category.entity.Category;
 import com.namo.spring.db.mysql.domains.record.entity.Diary;
 import com.namo.spring.db.mysql.domains.record.entity.DiaryImage;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
+import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 
 public class DiaryResponseConverter {
 
@@ -32,12 +35,26 @@ public class DiaryResponseConverter {
 	public static DiaryResponse.DiaryArchiveDto toDiaryArchiveDto(Participant participant) {
 		return DiaryResponse.DiaryArchiveDto.builder()
 			.scheduleDate(participant.getSchedule().getPeriod().getStartDate())
+			.categoryInfo(toCategoryInfoDto(participant.getCategory()))
 			.scheduleId(participant.getSchedule().getId())
 			.title(participant.getSchedule().getTitle())
 			.diarySummary(toDiarySummaryDto(participant.getDiary()))
 			.scheduleType(participant.getSchedule().getScheduleType())
-			.participantsCount(participant.getSchedule().getParticipantCount())
-			.participantsNames(participant.getSchedule().getParticipantNicknames())
+			.participantInfo(toParticipantInfo(participant.getSchedule()))
+			.build();
+	}
+
+	private static DiaryResponse.CategoryInfoDto toCategoryInfoDto(Category category) {
+		return DiaryResponse.CategoryInfoDto.builder()
+			.name(category.getName())
+			.color(category.getPalette().getColor())
+			.build();
+	}
+
+	private static DiaryResponse.ParticipantInfo toParticipantInfo(Schedule schedule) {
+		return DiaryResponse.ParticipantInfo.builder()
+			.participantsCount(schedule.getParticipantCount())
+			.participantsNames(schedule.getParticipantNicknames())
 			.build();
 	}
 
@@ -51,16 +68,26 @@ public class DiaryResponseConverter {
 			.build();
 	}
 
-	public static DiaryResponse.DiaryExistDateDto toDiaryExistDateDto(List<Participant> participants, int year,
-		int month) {
+	public static DiaryResponse.DiaryExistDateDto toDiaryExistDateDto(List<Participant> participants,
+		YearMonth yearMonth) {
 		return DiaryResponse.DiaryExistDateDto.builder()
-			.year(year)
-			.month(month)
+			.year(yearMonth.getYear())
+			.month(yearMonth.getMonth().getValue())
 			.dates(participants.stream()
 				.map(participant -> participant.getSchedule().getPeriod().getStartDate().getDayOfMonth()) // 날짜만 추출
 				.distinct() // 중복 제거 (만약 중복된 날짜가 있을 경우)
 				.sorted()
 				.collect(Collectors.toList()))
+			.build();
+	}
+
+	public static DiaryResponse.DayOfDiaryDto toDayOfDiaryDto(Participant participant) {
+		return DiaryResponse.DayOfDiaryDto.builder()
+			.scheduleType(participant.getSchedule().getScheduleType())
+			.categoryInfo(toCategoryInfoDto(participant.getCategory()))
+			.scheduleDate(participant.getSchedule().getPeriod().getStartDate())
+			.scheduleTitle(participant.getSchedule().getTitle())
+			.participantInfo(toParticipantInfo(participant.getSchedule()))
 			.build();
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
@@ -34,7 +34,8 @@ public class DiaryResponseConverter {
 
 	public static DiaryResponse.DiaryArchiveDto toDiaryArchiveDto(Participant participant) {
 		return DiaryResponse.DiaryArchiveDto.builder()
-			.scheduleDate(participant.getSchedule().getPeriod().getStartDate())
+			.scheduleStartDate(participant.getSchedule().getPeriod().getStartDate())
+			.scheduleEndDate(participant.getSchedule().getPeriod().getEndDate())
 			.categoryInfo(toCategoryInfoDto(participant.getCategory()))
 			.scheduleId(participant.getSchedule().getId())
 			.title(participant.getSchedule().getTitle())
@@ -85,7 +86,8 @@ public class DiaryResponseConverter {
 		return DiaryResponse.DayOfDiaryDto.builder()
 			.scheduleType(participant.getSchedule().getScheduleType())
 			.categoryInfo(toCategoryInfoDto(participant.getCategory()))
-			.scheduleDate(participant.getSchedule().getPeriod().getStartDate())
+			.scheduleStartDate(participant.getSchedule().getPeriod().getStartDate())
+			.scheduleEndDate(participant.getSchedule().getPeriod().getEndDate())
 			.scheduleTitle(participant.getSchedule().getTitle())
 			.diaryId(participant.getDiary().getId())
 			.participantInfo(toParticipantInfo(participant.getSchedule()))

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
@@ -87,6 +87,7 @@ public class DiaryResponseConverter {
 			.categoryInfo(toCategoryInfoDto(participant.getCategory()))
 			.scheduleDate(participant.getSchedule().getPeriod().getStartDate())
 			.scheduleTitle(participant.getSchedule().getTitle())
+			.diaryId(participant.getDiary().getId())
 			.participantInfo(toParticipantInfo(participant.getSchedule()))
 			.build();
 	}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
@@ -51,10 +51,11 @@ public class DiaryResponseConverter {
 			.build();
 	}
 
-	public static DiaryResponse.DiaryExistDateDto toDiaryExistDateDto(List<Participant> participants) {
+	public static DiaryResponse.DiaryExistDateDto toDiaryExistDateDto(List<Participant> participants, int year,
+		int month) {
 		return DiaryResponse.DiaryExistDateDto.builder()
-			.year(participants.get(0).getSchedule().getPeriod().getStartDate().getYear())
-			.month(participants.get(0).getSchedule().getPeriod().getStartDate().getMonthValue())
+			.year(year)
+			.month(month)
 			.dates(participants.stream()
 				.map(participant -> participant.getSchedule().getPeriod().getStartDate().getDayOfMonth()) // 날짜만 추출
 				.distinct() // 중복 제거 (만약 중복된 날짜가 있을 경우)

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
@@ -1,5 +1,8 @@
 package com.namo.spring.application.external.api.record.converter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.namo.spring.application.external.api.record.dto.DiaryResponse;
 import com.namo.spring.db.mysql.domains.record.entity.Diary;
 import com.namo.spring.db.mysql.domains.record.entity.DiaryImage;
@@ -45,6 +48,18 @@ public class DiaryResponseConverter {
 			.diaryImages(diary.getImages().stream()
 				.map(DiaryResponseConverter::toDiaryImageDto)
 				.toList())
+			.build();
+	}
+
+	public static DiaryResponse.DiaryExistDateDto toDiaryExistDateDto(List<Participant> participants) {
+		return DiaryResponse.DiaryExistDateDto.builder()
+			.year(participants.get(0).getSchedule().getPeriod().getStartDate().getYear())
+			.month(participants.get(0).getSchedule().getPeriod().getStartDate().getMonthValue())
+			.dates(participants.stream()
+				.map(participant -> participant.getSchedule().getPeriod().getStartDate().getDayOfMonth()) // 날짜만 추출
+				.distinct() // 중복 제거 (만약 중복된 날짜가 있을 경우)
+				.sorted()
+				.collect(Collectors.toList()))
 			.build();
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryRequest.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryRequest.java
@@ -26,6 +26,8 @@ public class DiaryRequest {
 		@Schema(description = "즐거움 지수를 넣어주세요 1~3", example = "3.0")
 		private double enjoyRating;
 		private List<CreateDiaryImageDto> diaryImages;
+		@Schema(description = "삭제할 이미지 ID를 넣어주세요", example = "1")
+		private List<Long> deleteImages;
 	}
 
 	@Getter

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -3,6 +3,8 @@ package com.namo.spring.application.external.api.record.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +15,11 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class DiaryDto {
+		@Schema(description = "일기 ID", example = "2")
 		private Long diaryId;
+		@Schema(description = "일기 내용", example = "재미있는 하루였다.. ㅎ")
 		private String content;
+		@Schema(description = "재미도", example = "1.0")
 		private double enjoyRating;
 		private List<DiaryImageDto> diaryImages;
 	}
@@ -23,8 +28,11 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class DiaryImageDto {
+		@Schema(description = "정렬 순서", example = "1")
 		private Integer orderNumber;
+		@Schema(description = "이미지 ID", example = "34")
 		private Long diaryImageId;
+		@Schema(description = "이미지 URL", example = "https://static.namong.shop/resized/origin/diary/image.png")
 		private String imageUrl;
 	}
 
@@ -35,9 +43,12 @@ public class DiaryResponse {
 		private CategoryInfoDto categoryInfo;
 		private LocalDateTime scheduleStartDate;
 		private LocalDateTime scheduleEndDate;
+		@Schema(description = "스케줄 ID", example = "11")
 		private Long scheduleId;
+		@Schema(description = "스케줄 제목", example = "저녁 약속")
 		private String title;
 		private DiarySummaryDto diarySummary;
+		@Schema(description = "개인 스케줄 : 0, 모임 스케줄 : 1", example = "0")
 		private int scheduleType;
 		private ParticipantInfo participantInfo;
 	}
@@ -46,7 +57,9 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class ParticipantInfo {
+		@Schema(description = "참여자 수", example = "1")
 		private int participantsCount;
+		@Schema(description = "참여자 이름 목록", example = "홍길동, 나몽")
 		private String participantsNames;
 	}
 
@@ -54,7 +67,9 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class DiarySummaryDto {
+		@Schema(description = "일기 ID", example = "2")
 		private Long diaryId;
+		@Schema(description = "일기 내용", example = "오늘 너무 재미있었다. ㅎㅎ")
 		private String content;
 		private List<DiaryImageDto> diaryImages;
 	}
@@ -65,6 +80,7 @@ public class DiaryResponse {
 	public static class DiaryExistDateDto {
 		private int year;
 		private int month;
+		@Schema(description = "일기가 존재하는 날짜", example = "1, 2, 3")
 		private List<Integer> dates;
 	}
 
@@ -72,11 +88,14 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class DayOfDiaryDto {
+		@Schema(description = "개인 스케줄 : 0, 모임 스케줄 : 1", example = "0")
 		private int scheduleType;
 		private CategoryInfoDto categoryInfo;
 		private LocalDateTime scheduleStartDate;
 		private LocalDateTime scheduleEndDate;
+		@Schema(description = "스케줄 이름", example = "점심 약속")
 		private String scheduleTitle;
+		@Schema(description = "일기 ID", example = "2")
 		private Long diaryId;
 		private ParticipantInfo participantInfo;
 	}
@@ -85,7 +104,9 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class CategoryInfoDto {
+		@Schema(description = "카테고리 이름", example = "개인 일정")
 		private String name;
+		@Schema(description = "카테고리 색상", example = "2131034735")
 		private int color;
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -32,11 +32,19 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class DiaryArchiveDto {
+		public CategoryInfoDto categoryInfo;
 		private LocalDateTime scheduleDate;
 		private Long scheduleId;
 		private String title;
 		private DiarySummaryDto diarySummary;
 		private int scheduleType;
+		private ParticipantInfo participantInfo;
+	}
+
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	public static class ParticipantInfo {
 		private int participantsCount;
 		private String participantsNames;
 	}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -75,6 +75,7 @@ public class DiaryResponse {
 		public CategoryInfoDto categoryInfo;
 		private LocalDateTime scheduleDate;
 		public String scheduleTitle;
+		public Long diaryId;
 		private ParticipantInfo participantInfo;
 	}
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -32,8 +32,9 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class DiaryArchiveDto {
-		public CategoryInfoDto categoryInfo;
-		private LocalDateTime scheduleDate;
+		private CategoryInfoDto categoryInfo;
+		private LocalDateTime scheduleStartDate;
+		private LocalDateTime scheduleEndDate;
 		private Long scheduleId;
 		private String title;
 		private DiarySummaryDto diarySummary;
@@ -71,11 +72,12 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class DayOfDiaryDto {
-		public int scheduleType;
-		public CategoryInfoDto categoryInfo;
-		private LocalDateTime scheduleDate;
-		public String scheduleTitle;
-		public Long diaryId;
+		private int scheduleType;
+		private CategoryInfoDto categoryInfo;
+		private LocalDateTime scheduleStartDate;
+		private LocalDateTime scheduleEndDate;
+		private String scheduleTitle;
+		private Long diaryId;
 		private ParticipantInfo participantInfo;
 	}
 
@@ -83,7 +85,7 @@ public class DiaryResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class CategoryInfoDto {
-		public String name;
-		public int color;
+		private String name;
+		private int color;
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -67,4 +67,22 @@ public class DiaryResponse {
 		private List<Integer> dates;
 	}
 
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	public static class DayOfDiaryDto {
+		public int scheduleType;
+		public CategoryInfoDto categoryInfo;
+		private LocalDateTime scheduleDate;
+		public String scheduleTitle;
+		private ParticipantInfo participantInfo;
+	}
+
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	public static class CategoryInfoDto {
+		public String name;
+		public int color;
+	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -50,4 +50,13 @@ public class DiaryResponse {
 		private List<DiaryImageDto> diaryImages;
 	}
 
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	public static class DiaryExistDateDto {
+		private int year;
+		private int month;
+		private List<Integer> dates;
+	}
+
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -14,6 +14,7 @@ public class DiaryResponse {
 	@Builder
 	@Getter
 	@AllArgsConstructor
+	@Schema(description = "일기 상세 정보 DTO")
 	public static class DiaryDto {
 		@Schema(description = "일기 ID", example = "2")
 		private Long diaryId;
@@ -27,6 +28,7 @@ public class DiaryResponse {
 	@Builder
 	@Getter
 	@AllArgsConstructor
+	@Schema(description = "일기 이미지 정보 DTO")
 	public static class DiaryImageDto {
 		@Schema(description = "정렬 순서", example = "1")
 		private Integer orderNumber;
@@ -39,6 +41,7 @@ public class DiaryResponse {
 	@Builder
 	@Getter
 	@AllArgsConstructor
+	@Schema(description = "일기 보관함 DTO")
 	public static class DiaryArchiveDto {
 		private CategoryInfoDto categoryInfo;
 		private LocalDateTime scheduleStartDate;
@@ -56,6 +59,7 @@ public class DiaryResponse {
 	@Builder
 	@Getter
 	@AllArgsConstructor
+	@Schema(description = "스케줄 참여자 정보 DTO")
 	public static class ParticipantInfo {
 		@Schema(description = "참여자 수", example = "1")
 		private int participantsCount;
@@ -66,6 +70,7 @@ public class DiaryResponse {
 	@Builder
 	@Getter
 	@AllArgsConstructor
+	@Schema(description = "일기 정보 DTO")
 	public static class DiarySummaryDto {
 		@Schema(description = "일기 ID", example = "2")
 		private Long diaryId;
@@ -77,6 +82,7 @@ public class DiaryResponse {
 	@Builder
 	@Getter
 	@AllArgsConstructor
+	@Schema(description = "일기 존재 날짜 DTO")
 	public static class DiaryExistDateDto {
 		private int year;
 		private int month;
@@ -87,6 +93,7 @@ public class DiaryResponse {
 	@Builder
 	@Getter
 	@AllArgsConstructor
+	@Schema(description = "일별 일기에 대한 스케줄 DTO")
 	public static class DayOfDiaryDto {
 		@Schema(description = "개인 스케줄 : 0, 모임 스케줄 : 1", example = "0")
 		private int scheduleType;
@@ -103,6 +110,7 @@ public class DiaryResponse {
 	@Builder
 	@Getter
 	@AllArgsConstructor
+	@Schema(description = "카테고리 정보 DTO")
 	public static class CategoryInfoDto {
 		@Schema(description = "카테고리 이름", example = "개인 일정")
 		private String name;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryImageManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryImageManageService.java
@@ -1,0 +1,68 @@
+package com.namo.spring.application.external.api.record.serivce;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.namo.spring.application.external.api.record.dto.DiaryRequest;
+import com.namo.spring.core.infra.common.aws.s3.FileUtils;
+import com.namo.spring.core.infra.common.constant.FilePath;
+import com.namo.spring.db.mysql.domains.record.entity.Diary;
+import com.namo.spring.db.mysql.domains.record.entity.DiaryImage;
+import com.namo.spring.db.mysql.domains.record.service.DiaryImageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DiaryImageManageService {
+
+	private final DiaryImageService diaryImageService;
+	private final FileUtils fileUtils;
+
+	/**
+	 * 일기의 이미지를 업데이트하는 메서드입니다.
+	 * !! 현재 기존이미지를 모두 지우고 재생성합니다. 삭제가 지정된 이미지만 클라우드에서 제거합니다.
+	 *
+	 * @param diary   업데이트할 일기
+	 * @param request
+	 */
+	public void updateDiaryImage(Diary diary, DiaryRequest.UpdateDiaryDto request) {
+		request.getDeleteImages().forEach(this::deleteFromCloud);
+		diaryImageService.deleteAll(diary);
+		createDiaryImages(diary, request.getDiaryImages());
+	}
+
+	/**
+	 * 클라우드(S3) 에서 이미지를 삭제하는 메서드입니다. (원본, 리사이징 본 모두 삭제)
+	 * !! 만약 이미지가 존재하지 않으면 로그만 남기고 Continue 됩니다.
+	 *
+	 * @param imageId 삭제하려는 Image ID
+	 */
+	private void deleteFromCloud(Long imageId) {
+		// 이미지가 존재하지 않을 때 로그를 남기고, 예외는 발생시키지 않음
+		diaryImageService.readDiaryImage(imageId).ifPresentOrElse(diaryImage -> {
+			fileUtils.delete(diaryImage.getImageUrl(), FilePath.DIARY_IMG);
+			fileUtils.delete(diaryImage.getImageUrl(), FilePath.RESIZED_DIARY_IMG);
+		}, () -> {
+			log.info("Image with ID " + imageId + " does not exist. No deletion performed.");
+		});
+	}
+
+	/**
+	 * 일기 이미지를 생성하는 메서드입니다.
+	 *
+	 * @param diary       이미지가 연결될 일기
+	 * @param diaryImages
+	 */
+	public void createDiaryImages(Diary diary, List<DiaryRequest.CreateDiaryImageDto> diaryImages) {
+		if (!diaryImages.isEmpty()) {
+			diaryImages.forEach(diaryImage -> {
+				DiaryImage image = DiaryImage.of(diary, diaryImage.getImageUrl(), diaryImage.getOrderNumber());
+				diaryImageService.createDiaryImage(image);
+			});
+		}
+	}
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
@@ -23,6 +23,14 @@ public class DiaryManageService {
 	private final DiaryService diaryService;
 	private final DiaryImageService diaryImageService;
 
+	/**
+	 * 나의 일기를 가져오는 메서드입니다.
+	 * !!다이어리의 존재 여부, 나의 다이어리 여부를 검증합니다.
+	 *
+	 * @param diaryId  일기 ID
+	 * @param memberId 사용자 ID
+	 * @return Diary
+	 */
 	public Diary getMyDiary(Long diaryId, Long memberId) {
 		Diary diary = diaryService.readDiary(diaryId)
 			.orElseThrow(() -> new DiaryException(ErrorStatus.NOT_FOUND_DIARY_FAILURE));
@@ -31,12 +39,26 @@ public class DiaryManageService {
 		return diary;
 	}
 
+	/**
+	 * 참여자의 다이어리를 가져오는 메서드입니다.
+	 * !! 다이어리가 작성되었는지 여부를 검증합니다.
+	 *
+	 * @param participant 참여자
+	 * @return Diary
+	 */
 	public Diary getParticipantDiary(Participant participant) {
 		if (!participant.isHasDiary())
 			throw new DiaryException(ErrorStatus.NOT_WRITTEN_DIARY_FAILURE);
 		return participant.getDiary();
 	}
 
+	/**
+	 * 다이어리를 만드는 메서드입니다.
+	 * !! 다이어리가 이미 존재하는지를 검증합니다.
+	 *
+	 * @param request
+	 * @param participant 참여자
+	 */
 	public void makeDiary(DiaryRequest.CreateDiaryDto request, Participant participant) {
 		if (participant.isHasDiary())
 			throw new MemberException(ErrorStatus.ALREADY_WRITTEN_DIARY_FAILURE);
@@ -45,6 +67,13 @@ public class DiaryManageService {
 		createDiaryImages(diary, request.getDiaryImages());
 	}
 
+	/**
+	 * 다이어리를 업데이트 하는 메서드입니다.
+	 * !! 다이어리 이미지에 대해 PUT 형태의 업데이트를 진행합니다.
+	 *
+	 * @param diary   타겟 일기
+	 * @param request 업데이트 정보
+	 */
 	public void updateDiary(Diary diary, DiaryRequest.UpdateDiaryDto request) {
 		diary.update(request.getContent(), request.getEnjoyRating());
 		diaryImageService.deleteAll(diary);

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
@@ -1,15 +1,11 @@
 package com.namo.spring.application.external.api.record.serivce;
 
-import java.util.List;
-
 import org.springframework.stereotype.Component;
 
 import com.namo.spring.application.external.api.record.dto.DiaryRequest;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.db.mysql.domains.record.entity.Diary;
-import com.namo.spring.db.mysql.domains.record.entity.DiaryImage;
 import com.namo.spring.db.mysql.domains.record.exception.DiaryException;
-import com.namo.spring.db.mysql.domains.record.service.DiaryImageService;
 import com.namo.spring.db.mysql.domains.record.service.DiaryService;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.user.exception.MemberException;
@@ -21,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class DiaryManageService {
 
 	private final DiaryService diaryService;
-	private final DiaryImageService diaryImageService;
+	private final DiaryImageManageService diaryImageManageService;
 
 	/**
 	 * 나의 일기를 가져오는 메서드입니다.
@@ -64,28 +60,18 @@ public class DiaryManageService {
 			throw new MemberException(ErrorStatus.ALREADY_WRITTEN_DIARY_FAILURE);
 		Diary diary = Diary.of(participant, request.getContent(), request.getEnjoyRating());
 		diaryService.createDiary(diary);
-		createDiaryImages(diary, request.getDiaryImages());
+		diaryImageManageService.createDiaryImages(diary, request.getDiaryImages());
 	}
 
 	/**
 	 * 다이어리를 업데이트 하는 메서드입니다.
-	 * !! 다이어리 이미지에 대해 PUT 형태의 업데이트를 진행합니다.
+	 * !! 일기 이미지에 대한 업데이트 방식은 DiaryImageManageService가 책임을 가집니다.
 	 *
 	 * @param diary   타겟 일기
 	 * @param request 업데이트 정보
 	 */
 	public void updateDiary(Diary diary, DiaryRequest.UpdateDiaryDto request) {
 		diary.update(request.getContent(), request.getEnjoyRating());
-		diaryImageService.deleteAll(diary);
-		createDiaryImages(diary, request.getDiaryImages());
-	}
-
-	private void createDiaryImages(Diary diary, List<DiaryRequest.CreateDiaryImageDto> diaryImages) {
-		if (!diaryImages.isEmpty()) {
-			diaryImages.forEach(diaryImage -> {
-				DiaryImage image = DiaryImage.of(diary, diaryImage.getImageUrl(), diaryImage.getOrderNumber());
-				diaryImageService.createDiaryImage(image);
-			});
-		}
+		diaryImageManageService.updateDiaryImage(diary, request);
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
@@ -1,5 +1,7 @@
 package com.namo.spring.application.external.api.record.usecase;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 import org.springframework.data.domain.PageRequest;
@@ -47,7 +49,7 @@ public class DiaryUseCase {
 	}
 
 	@Transactional(readOnly = true)
-	public List<DiaryResponse.DiaryArchiveDto> getDiaryArchiveDto(Long memberId, int page, String filterType,
+	public List<DiaryResponse.DiaryArchiveDto> getDiaryArchive(Long memberId, int page, String filterType,
 		String keyword) {
 		Pageable pageable = PageRequest.of(page - 1, 5);
 		List<Participant> allMyParticipant = participantManageService.getMyParticipationForDiary(memberId, pageable,
@@ -58,10 +60,17 @@ public class DiaryUseCase {
 	}
 
 	@Transactional(readOnly = true)
-	public DiaryResponse.DiaryExistDateDto getExistDiaryDate(Long memberId, int year, int month) {
-		List<Participant> participants = participantManageService.getMyParticipantByMonthForDiary(memberId, year,
-			month
+	public DiaryResponse.DiaryExistDateDto getExistDiaryDate(Long memberId, YearMonth yearMonth) {
+		List<Participant> participants = participantManageService.getMyParticipantByMonthForDiary(memberId, yearMonth
 		);
-		return DiaryResponseConverter.toDiaryExistDateDto(participants, year, month);
+		return DiaryResponseConverter.toDiaryExistDateDto(participants, yearMonth);
+	}
+
+	@Transactional(readOnly = true)
+	public List<DiaryResponse.DayOfDiaryDto> getDayDiaryList(Long memberId, LocalDate localDate) {
+		List<Participant> participants = participantManageService.getMyParticipantByDayForDiary(memberId, localDate);
+		return participants.stream()
+			.map(DiaryResponseConverter::toDayOfDiaryDto)
+			.toList();
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
@@ -2,6 +2,8 @@ package com.namo.spring.application.external.api.record.usecase;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,10 +49,19 @@ public class DiaryUseCase {
 	@Transactional(readOnly = true)
 	public List<DiaryResponse.DiaryArchiveDto> getDiaryArchiveDto(Long memberId, int page, String filterType,
 		String keyword) {
-		List<Participant> allMyParticipant = participantManageService.getMyParticipationForArchive(memberId, page,
+		Pageable pageable = PageRequest.of(page - 1, 5);
+		List<Participant> allMyParticipant = participantManageService.getMyParticipationForDiary(memberId, pageable,
 			filterType, keyword);
 		return allMyParticipant.stream()
 			.map(DiaryResponseConverter::toDiaryArchiveDto)
 			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public DiaryResponse.DiaryExistDateDto getExistDiaryDate(Long memberId, int year, int month) {
+		List<Participant> participants = participantManageService.getMyParticipantByMonthForDiary(memberId, year,
+			month
+		);
+		return DiaryResponseConverter.toDiaryExistDateDto(participants);
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
@@ -62,6 +62,6 @@ public class DiaryUseCase {
 		List<Participant> participants = participantManageService.getMyParticipantByMonthForDiary(memberId, year,
 			month
 		);
-		return DiaryResponseConverter.toDiaryExistDateDto(participants);
+		return DiaryResponseConverter.toDiaryExistDateDto(participants, year, month);
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
@@ -1,5 +1,13 @@
 package com.namo.spring.application.external.api.schedule.service;
 
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
 import com.namo.spring.application.external.api.schedule.dto.ScheduleRequest;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.db.mysql.domains.category.entity.Palette;
@@ -17,112 +25,117 @@ import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 import com.namo.spring.db.mysql.domains.user.exception.MemberException;
 import com.namo.spring.db.mysql.domains.user.service.FriendshipService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ParticipantManageService {
-    private static final Long MEETING_SCHEDULE_OWNER_PALETTE_ID = ColorChip.getMeetingScheduleOwnerPaletteId();
-    private static final long[] PALETTE_IDS = PaletteEnum.getPaletteColorIds();
-    private final ParticipantMaker participantMaker;
-    private final ParticipationActionManager participationActionManager;
-    private final FriendshipService friendshipService;
-    private final ParticipantService participantService;
+	private static final Long MEETING_SCHEDULE_OWNER_PALETTE_ID = ColorChip.getMeetingScheduleOwnerPaletteId();
+	private static final long[] PALETTE_IDS = PaletteEnum.getPaletteColorIds();
+	private final ParticipantMaker participantMaker;
+	private final ParticipationActionManager participationActionManager;
+	private final FriendshipService friendshipService;
+	private final ParticipantService participantService;
 
-    public void createPersonalScheduleParticipant(Member member, Schedule schedule, Long categoryId) {
-        participantMaker.makeScheduleOwner(schedule, member, categoryId, null);
-    }
+	public void createPersonalScheduleParticipant(Member member, Schedule schedule, Long categoryId) {
+		participantMaker.makeScheduleOwner(schedule, member, categoryId, null);
+	}
 
-    public void createMeetingScheduleParticipants(Member owner, Schedule schedule, List<Member> participants) {
-        participantMaker.makeScheduleOwner(schedule, owner, null, MEETING_SCHEDULE_OWNER_PALETTE_ID);
-        schedule.addActiveParticipant(owner.getNickname());
-        participants.forEach(participant -> participantMaker.makeMeetingScheduleParticipant(schedule, participant));
-    }
+	public void createMeetingScheduleParticipants(Member owner, Schedule schedule, List<Member> participants) {
+		participantMaker.makeScheduleOwner(schedule, owner, null, MEETING_SCHEDULE_OWNER_PALETTE_ID);
+		schedule.addActiveParticipant(owner.getNickname());
+		participants.forEach(participant -> participantMaker.makeMeetingScheduleParticipant(schedule, participant));
+	}
 
-    public List<Member> getFriendshipValidatedParticipants(Long ownerId, List<Long> memberIds) {
-        List<Member> friends = friendshipService.readFriendshipsByMemberIdAndFriendIds(ownerId, memberIds).stream()
-                .map(Friendship::getFriend)
-                .collect(Collectors.toList());
-        if (memberIds.size() != friends.size()) {
-            throw new MemberException(ErrorStatus.NOT_FOUND_FRIENDSHIP_FAILURE);
-        }
-        return friends;
-    }
+	public List<Member> getFriendshipValidatedParticipants(Long ownerId, List<Long> memberIds) {
+		List<Member> friends = friendshipService.readFriendshipsByMemberIdAndFriendIds(ownerId, memberIds).stream()
+			.map(Friendship::getFriend)
+			.collect(Collectors.toList());
+		if (memberIds.size() != friends.size()) {
+			throw new MemberException(ErrorStatus.NOT_FOUND_FRIENDSHIP_FAILURE);
+		}
+		return friends;
+	}
 
-    public Participant getValidatedMeetingParticipantWithSchedule(Long memberId, Long scheduleId) {
-        return participantService.readParticipantByScheduleIdAndMemberId(scheduleId, memberId).orElseThrow(
-                () -> new ScheduleException(ErrorStatus.NOT_SCHEDULE_PARTICIPANT));
-    }
+	public Participant getValidatedMeetingParticipantWithSchedule(Long memberId, Long scheduleId) {
+		return participantService.readParticipantByScheduleIdAndMemberId(scheduleId, memberId).orElseThrow(
+			() -> new ScheduleException(ErrorStatus.NOT_SCHEDULE_PARTICIPANT));
+	}
 
-    public void activateParticipant(Long memberId, Long scheduleId) {
-        Participant participant = getValidatedMeetingParticipantWithSchedule(scheduleId, memberId);
-        Long paletteId = selectPaletteColorId(scheduleId);
-        participationActionManager.activateParticipant(participant.getSchedule(), participant, paletteId);
-    }
+	public void activateParticipant(Long memberId, Long scheduleId) {
+		Participant participant = getValidatedMeetingParticipantWithSchedule(scheduleId, memberId);
+		Long paletteId = selectPaletteColorId(scheduleId);
+		participationActionManager.activateParticipant(participant.getSchedule(), participant, paletteId);
+	}
 
-    private Long selectPaletteColorId(Long scheduleId) {
-        List<Long> participantsColors = getMeetingScheduleParticipants(scheduleId, ParticipantStatus.ACTIVE)
-                .stream().map(Participant::getPalette).map(Palette::getId).collect(Collectors.toList());
-        return Arrays.stream(PALETTE_IDS)
-                .filter((color) -> !participantsColors.contains(color))
-                .findFirst()
-                .orElseThrow(() -> new PaletteException(ErrorStatus.NOT_FOUND_COLOR));
-    }
+	private Long selectPaletteColorId(Long scheduleId) {
+		List<Long> participantsColors = getMeetingScheduleParticipants(scheduleId, ParticipantStatus.ACTIVE)
+			.stream().map(Participant::getPalette).map(Palette::getId).collect(Collectors.toList());
+		return Arrays.stream(PALETTE_IDS)
+			.filter((color) -> !participantsColors.contains(color))
+			.findFirst()
+			.orElseThrow(() -> new PaletteException(ErrorStatus.NOT_FOUND_COLOR));
+	}
 
-    public void updateMeetingScheduleParticipants(Long ownerId, Schedule schedule, ScheduleRequest.PatchMeetingScheduleDto dto) {
-        if (!dto.getParticipantsToAdd().isEmpty()) {
-            List<Member> participantsToAdd = getFriendshipValidatedParticipants(ownerId, dto.getParticipantsToAdd());
-            participantsToAdd.forEach(participant -> participantMaker.makeMeetingScheduleParticipant(schedule, participant));
-        }
+	public void updateMeetingScheduleParticipants(Long ownerId, Schedule schedule,
+		ScheduleRequest.PatchMeetingScheduleDto dto) {
+		if (!dto.getParticipantsToAdd().isEmpty()) {
+			List<Member> participantsToAdd = getFriendshipValidatedParticipants(ownerId, dto.getParticipantsToAdd());
+			participantsToAdd.forEach(
+				participant -> participantMaker.makeMeetingScheduleParticipant(schedule, participant));
+		}
 
-        if (!dto.getParticipantsToRemove().isEmpty()) {
-            List<Participant> participantsToRemove = participantService.readParticipantsByIdAndScheduleId(dto.getParticipantsToRemove(), schedule.getId(), ParticipantStatus.ACTIVE);
-            if (participantsToRemove.isEmpty()) {
-                throw new ScheduleException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE);
-            }
-            participationActionManager.removeParticipants(schedule, participantsToRemove);
-        }
-    }
+		if (!dto.getParticipantsToRemove().isEmpty()) {
+			List<Participant> participantsToRemove = participantService.readParticipantsByIdAndScheduleId(
+				dto.getParticipantsToRemove(), schedule.getId(), ParticipantStatus.ACTIVE);
+			if (participantsToRemove.isEmpty()) {
+				throw new ScheduleException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE);
+			}
+			participationActionManager.removeParticipants(schedule, participantsToRemove);
+		}
+	}
 
-    public List<Participant> getMeetingScheduleParticipants(Long scheduleId, ParticipantStatus status) {
-        List<Participant> participants = participantService.readParticipantsByScheduleIdAndStatusAndType(scheduleId, ScheduleType.MEETING, status);
-        if (participants.isEmpty()) {
-            throw new ScheduleException(ErrorStatus.SCHEDULE_PARTICIPANT_IS_EMPTY_ERROR);
-        } else return participants;
-    }
+	public List<Participant> getMeetingScheduleParticipants(Long scheduleId, ParticipantStatus status) {
+		List<Participant> participants = participantService.readParticipantsByScheduleIdAndStatusAndType(scheduleId,
+			ScheduleType.MEETING, status);
+		if (participants.isEmpty()) {
+			throw new ScheduleException(ErrorStatus.SCHEDULE_PARTICIPANT_IS_EMPTY_ERROR);
+		} else
+			return participants;
+	}
 
-    public Participant getScheduleParticipant(Long memberId, Long scheduleId) {
-        return participantService.readParticipant(memberId, scheduleId)
-                .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE));
-    }
+	public Participant getScheduleParticipant(Long memberId, Long scheduleId) {
+		return participantService.readParticipant(memberId, scheduleId)
+			.orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE));
+	}
 
-    public List<Participant> getMyParticipationForArchive(Long memberId, int page, String filterType, String keyword) {
-        Pageable pageable = PageRequest.of(page - 1, 5);
-        if (filterType == null || filterType.isEmpty())
-            return participantService.readParticipantsForDiary(memberId, pageable);
+	public List<Participant> getMyParticipationForDiary(Long memberId, Pageable pageable, String filterType,
+		String keyword) {
+		if (filterType == null || filterType.isEmpty())
+			return participantService.readParticipantsHasDiary(memberId, pageable);
 
-        switch (filterType) {
-            case "ScheduleName" -> {
-                return participantService.readParticipantByScheduleName(memberId, pageable, keyword);
-            }
-            case "DiaryContent" -> {
-                return participantService.readParticipantByDiaryContent(memberId, pageable, keyword);
-            }
-            case "MemberNickname" -> {
-                return participantService.readParticipantByMember(memberId, pageable, keyword);
-            }
-            default -> {
-                throw new DiaryException(ErrorStatus.NOT_FILTERTYPE_OF_ARCHIVE);
-            }
-        }
-    }
+		switch (filterType) {
+			case "ScheduleName" -> {
+				return participantService.readParticipantHasDiaryByScheduleName(memberId, pageable, keyword);
+			}
+			case "DiaryContent" -> {
+				return participantService.readParticipantHasDiaryByDiaryContent(memberId, pageable, keyword);
+			}
+			case "MemberNickname" -> {
+				return participantService.readParticipantHasDiaryByMember(memberId, pageable, keyword);
+			}
+			default -> {
+				throw new DiaryException(ErrorStatus.NOT_FILTERTYPE_OF_ARCHIVE);
+			}
+		}
+	}
+
+	public List<Participant> getMyParticipantByMonthForDiary(Long memberId, int year, int month) {
+		LocalDate startDate = LocalDate.of(year, month, 1); // 해당 월의 첫 번째 날
+		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth()); // 해당 월의 마지막 날
+		return participantService.readParticipantHasDiaryByMonth(memberId, startDate, endDate);
+	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
@@ -1,6 +1,6 @@
 package com.namo.spring.application.external.api.schedule.service;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -134,8 +134,11 @@ public class ParticipantManageService {
 	}
 
 	public List<Participant> getMyParticipantByMonthForDiary(Long memberId, int year, int month) {
-		LocalDate startDate = LocalDate.of(year, month, 1); // 해당 월의 첫 번째 날
-		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth()); // 해당 월의 마지막 날
-		return participantService.readParticipantHasDiaryByMonth(memberId, startDate, endDate);
+		LocalDateTime startDateTime = LocalDateTime.of(year, month, 1, 0, 0, 0);
+		LocalDateTime endDateTime = startDateTime.withDayOfMonth(startDateTime.toLocalDate().lengthOfMonth())
+			.withHour(23)
+			.withMinute(59)
+			.withSecond(59);
+		return participantService.readParticipantHasDiaryByMonth(memberId, startDateTime, endDateTime);
 	}
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
@@ -1,6 +1,8 @@
 package com.namo.spring.application.external.api.schedule.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -112,6 +114,15 @@ public class ParticipantManageService {
 			.orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_PARTICIPANT_FAILURE));
 	}
 
+	/**
+	 * 필터에 따라 검색하여 일기가 존재하는 참여 정보 목록을 입력된 페이지 객체 만큼 반환하는 메서드입니다. 필터가 없다면 기본 조회됩니다.
+	 *
+	 * @param memberId
+	 * @param pageable
+	 * @param filterType (ScheduleName, DiaryContent, MemberNickname)
+	 * @param keyword
+	 * @return 일기가 작성된 참여 정보 목록 (필터에 따라 다름)
+	 */
 	public List<Participant> getMyParticipationForDiary(Long memberId, Pageable pageable, String filterType,
 		String keyword) {
 		if (filterType == null || filterType.isEmpty())
@@ -133,12 +144,30 @@ public class ParticipantManageService {
 		}
 	}
 
-	public List<Participant> getMyParticipantByMonthForDiary(Long memberId, int year, int month) {
-		LocalDateTime startDateTime = LocalDateTime.of(year, month, 1, 0, 0, 0);
-		LocalDateTime endDateTime = startDateTime.withDayOfMonth(startDateTime.toLocalDate().lengthOfMonth())
-			.withHour(23)
-			.withMinute(59)
-			.withSecond(59);
-		return participantService.readParticipantHasDiaryByMonth(memberId, startDateTime, endDateTime);
+	/**
+	 * 해당 월의 00:00:00 부터 해당 월의 마지막날 23:59:59 까지 스케줄에 대하여 작성된 일기가 있는 참여정보 목록을 가져오는 메서드 입니다.
+	 *
+	 * @param memberId
+	 * @param yearMonth
+	 * @return 일기가 작성된 참여 정보 목록
+	 */
+	public List<Participant> getMyParticipantByMonthForDiary(Long memberId, YearMonth yearMonth) {
+		LocalDateTime startDateTime = yearMonth.atDay(1).atStartOfDay();
+		LocalDateTime endDateTime = yearMonth.atEndOfMonth().atTime(23, 59, 59);
+		return participantService.readParticipantHasDiaryByDateRange(memberId, startDateTime, endDateTime);
 	}
+
+	/**
+	 * 해당 날짜의 시작 시각 00:00:00 부터 끝 시각 23:59:59 사이의 스케줄에 대하여 작성된 일기 정보가 있는 참여정보 목록을 가져오는 메서드입니다.
+	 *
+	 * @param memberId
+	 * @param localDate
+	 * @return 일기가 작성된 참여 정보 목록
+	 */
+	public List<Participant> getMyParticipantByDayForDiary(Long memberId, LocalDate localDate) {
+		LocalDateTime startDateTime = localDate.atStartOfDay(); // 해당 날 00:00:00
+		LocalDateTime endDateTime = localDate.atTime(23, 59, 59); // 해당 날 23:59:59
+		return participantService.readParticipantHasDiaryByDateRange(memberId, startDateTime, endDateTime);
+	}
+
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
@@ -117,10 +117,10 @@ public class ParticipantManageService {
 	/**
 	 * 필터에 따라 검색하여 일기가 존재하는 참여 정보 목록을 입력된 페이지 객체 만큼 반환하는 메서드입니다. 필터가 없다면 기본 조회됩니다.
 	 *
-	 * @param memberId
-	 * @param pageable
-	 * @param filterType (ScheduleName, DiaryContent, MemberNickname)
-	 * @param keyword
+	 * @param memberId   사용자 ID
+	 * @param pageable   페이징 할 양
+	 * @param filterType (ScheduleName, DiaryContent, MemberNickname) 필터
+	 * @param keyword    키워드
 	 * @return 일기가 작성된 참여 정보 목록 (필터에 따라 다름)
 	 */
 	public List<Participant> getMyParticipationForDiary(Long memberId, Pageable pageable, String filterType,
@@ -147,8 +147,8 @@ public class ParticipantManageService {
 	/**
 	 * 해당 월의 00:00:00 부터 해당 월의 마지막날 23:59:59 까지 스케줄에 대하여 작성된 일기가 있는 참여정보 목록을 가져오는 메서드 입니다.
 	 *
-	 * @param memberId
-	 * @param yearMonth
+	 * @param memberId  사용자 ID
+	 * @param yearMonth 년:월
 	 * @return 일기가 작성된 참여 정보 목록
 	 */
 	public List<Participant> getMyParticipantByMonthForDiary(Long memberId, YearMonth yearMonth) {
@@ -160,8 +160,8 @@ public class ParticipantManageService {
 	/**
 	 * 해당 날짜의 시작 시각 00:00:00 부터 끝 시각 23:59:59 사이의 스케줄에 대하여 작성된 일기 정보가 있는 참여정보 목록을 가져오는 메서드입니다.
 	 *
-	 * @param memberId
-	 * @param localDate
+	 * @param memberId  사용자 ID
+	 * @param localDate 년:월:일
 	 * @return 일기가 작성된 참여 정보 목록
 	 */
 	public List<Participant> getMyParticipantByDayForDiary(Long memberId, LocalDate localDate) {

--- a/core/core-infra/src/main/java/com/namo/spring/core/infra/common/constant/FilePath.java
+++ b/core/core-infra/src/main/java/com/namo/spring/core/infra/common/constant/FilePath.java
@@ -4,13 +4,16 @@ import lombok.Getter;
 
 @Getter
 public enum FilePath {
+	CDN_PATH("namong", "https://static.namong.shop/"),
 	//v1
 	MEETING_ACTIVITY_IMG("", "group/activity/"),
 	MEETING_PROFILE_IMG("", "group/profile/"),
 	INVITATION_ACTIVITY_IMG("", "invitation/activity/"),
 	//v2
 	ACTIVITY_IMG("activity", "origin/activity"),
-	DIARY_IMG("diary", "origin/diary");;
+	RESIZED_ACTIVITY_IMG("activity", "resized/origin/activity"),
+	DIARY_IMG("diary", "origin/diary"),
+	RESIZED_DIARY_IMG("diary", "resized/origin/diary");
 
 	private final String prefix;
 	private final String path;

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -1,98 +1,115 @@
 package com.namo.spring.db.mysql.domains.schedule.repository;
 
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
-import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
-import com.namo.spring.db.mysql.domains.schedule.type.ParticipantStatus;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
+import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
+import com.namo.spring.db.mysql.domains.schedule.type.ParticipantStatus;
+
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
-    List<Participant> findAllByScheduleId(Long scheduleId);
+	List<Participant> findAllByScheduleId(Long scheduleId);
 
-    @Query("SELECT p FROM Participant p JOIN p.schedule s JOIN p.member m WHERE p.member.id = :memberId AND p.status = 'ACTIVE' AND s.scheduleType = :scheduleType")
-    List<Participant> findParticipantsByMemberAndScheduleType(Long memberId, int scheduleType);
+	@Query("SELECT p FROM Participant p JOIN p.schedule s JOIN p.member m WHERE p.member.id = :memberId AND p.status = 'ACTIVE' AND s.scheduleType = :scheduleType")
+	List<Participant> findParticipantsByMemberAndScheduleType(Long memberId, int scheduleType);
 
-    boolean existsByScheduleIdAndMemberId(Long scheduleId, Long memberId);
+	boolean existsByScheduleIdAndMemberId(Long scheduleId, Long memberId);
 
-    @Query("SELECT p FROM Participant p JOIN FETCH p.schedule s LEFT JOIN FETCH p.palette " +
-            "WHERE s.id = :scheduleId AND s.scheduleType = :scheduleType " +
-            "AND (:status IS NULL OR p.status = :status)")
-    List<Participant> findParticipantsByScheduleIdAndStatusAndType(Long scheduleId, int scheduleType, ParticipantStatus status);
+	@Query("SELECT p FROM Participant p JOIN FETCH p.schedule s LEFT JOIN FETCH p.palette " +
+		"WHERE s.id = :scheduleId AND s.scheduleType = :scheduleType " +
+		"AND (:status IS NULL OR p.status = :status)")
+	List<Participant> findParticipantsByScheduleIdAndStatusAndType(Long scheduleId, int scheduleType,
+		ParticipantStatus status);
 
-    @Query("SELECT p FROM Participant p JOIN FETCH p.schedule s WHERE s.id = :scheduleId AND p.member.id = :memberId")
-    Optional<Participant> findParticipantByScheduleIdAndMemberId(Long scheduleId, Long memberId);
+	@Query("SELECT p FROM Participant p JOIN FETCH p.schedule s WHERE s.id = :scheduleId AND p.member.id = :memberId")
+	Optional<Participant> findParticipantByScheduleIdAndMemberId(Long scheduleId, Long memberId);
 
-    @Query("SELECT p " +
-            "FROM Participant p " +
-            "JOIN p.schedule s " +
-            "LEFT JOIN FETCH p.member m " +
-            "LEFT JOIN FETCH p.anonymous a " +
-            "WHERE p.id in :ids AND s.id = :scheduleId AND p.status = :status")
-    List<Participant> findParticipantByIdAndScheduleId(List<Long> ids, Long scheduleId, ParticipantStatus status);
+	@Query("SELECT p " +
+		"FROM Participant p " +
+		"JOIN p.schedule s " +
+		"LEFT JOIN FETCH p.member m " +
+		"LEFT JOIN FETCH p.anonymous a " +
+		"WHERE p.id in :ids AND s.id = :scheduleId AND p.status = :status")
+	List<Participant> findParticipantByIdAndScheduleId(List<Long> ids, Long scheduleId, ParticipantStatus status);
 
-    @Query("SELECT DISTINCT new com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery(" +
-            "p.id, p.palette.id, m.id, m.nickname, s, p.category.isShared" +
-            ") FROM Participant p " +
-            "JOIN p.schedule s " +
-            "JOIN p.member m " +
-            "WHERE m.id IN :memberIds " +
-            "AND p.status = 'ACTIVE' " +
-            "AND (s.period.startDate < :endDate " +
-            "AND s.period.endDate >= :startDate) " +
-            "ORDER BY s.period.startDate ASC")
-    List<ScheduleParticipantQuery> findParticipantsWithUserAndScheduleByPeriod(
-            List<Long> memberIds,
-            LocalDateTime startDate,
-            LocalDateTime endDate
-    );
+	@Query("SELECT DISTINCT new com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery(" +
+		"p.id, p.palette.id, m.id, m.nickname, s, p.category.isShared" +
+		") FROM Participant p " +
+		"JOIN p.schedule s " +
+		"JOIN p.member m " +
+		"WHERE m.id IN :memberIds " +
+		"AND p.status = 'ACTIVE' " +
+		"AND (s.period.startDate < :endDate " +
+		"AND s.period.endDate >= :startDate) " +
+		"ORDER BY s.period.startDate ASC")
+	List<ScheduleParticipantQuery> findParticipantsWithUserAndScheduleByPeriod(
+		List<Long> memberIds,
+		LocalDateTime startDate,
+		LocalDateTime endDate
+	);
 
-    @Query("SELECT p FROM Participant p " +
-            "JOIN FETCH p.schedule s " +
-            "JOIN FETCH p.category c " +
-            "WHERE p.member.id = :memberId " +
-            "AND p.status = 'ACTIVE' " +
-            "AND (s.period.startDate < :endDate " +
-            "AND s.period.endDate >= :startDate) " +
-            "AND (:isShared IS NULL OR c.isShared = :isShared) " +
-            "ORDER BY s.period.startDate ASC")
-    List<Participant> findParticipantsWithScheduleAndCategoryByPeriod(
-            Long memberId,
-            Boolean isShared,
-            LocalDateTime startDate,
-            LocalDateTime endDate
-    );
+	@Query("SELECT p FROM Participant p " +
+		"JOIN FETCH p.schedule s " +
+		"JOIN FETCH p.category c " +
+		"WHERE p.member.id = :memberId " +
+		"AND p.status = 'ACTIVE' " +
+		"AND (s.period.startDate < :endDate " +
+		"AND s.period.endDate >= :startDate) " +
+		"AND (:isShared IS NULL OR c.isShared = :isShared) " +
+		"ORDER BY s.period.startDate ASC")
+	List<Participant> findParticipantsWithScheduleAndCategoryByPeriod(
+		Long memberId,
+		Boolean isShared,
+		LocalDateTime startDate,
+		LocalDateTime endDate
+	);
 
-    void deleteByIdIn(List<Long> id);
+	void deleteByIdIn(List<Long> id);
 
-    Optional<Participant> findParticipantByMemberIdAndScheduleId(Long memberId, Long scheduleId);
+	Optional<Participant> findParticipantByMemberIdAndScheduleId(Long memberId, Long scheduleId);
 
-    @Query("SELECT p "
-            + "FROM Participant p "
-            + "WHERE p.hasDiary = true and p.member.id = :memberId "
-            + "order by p.schedule.period.startDate desc ")
-    List<Participant> findAllByMemberIdAndHasDiary(Long memberId, Pageable pageable);
+	@Query("SELECT p "
+		+ "FROM Participant p "
+		+ "WHERE p.hasDiary = true and p.member.id = :memberId "
+		+ "order by p.schedule.period.startDate desc ")
+	List<Participant> findAllByMemberIdAndHasDiary(@Param("memberId") Long memberId, Pageable pageable);
 
-    @Query("SELECT p "
-            + "FROM Participant p "
-            + "WHERE p.hasDiary = true AND p.member.id = :memberId AND p.schedule.title LIKE %:keyword% "
-            + "ORDER BY p.schedule.period.startDate DESC")
-    List<Participant> findAllByScheduleTitleAndHasDiary(Long memberId, String keyword, Pageable pageable);
+	@Query("SELECT p "
+		+ "FROM Participant p "
+		+ "WHERE p.hasDiary = true AND p.member.id = :memberId AND p.schedule.title LIKE %:keyword% "
+		+ "ORDER BY p.schedule.period.startDate DESC")
+	List<Participant> findAllByScheduleTitleAndHasDiary(@Param("memberId") Long memberId,
+		@Param("keyword") String keyword, Pageable pageable);
 
-    @Query("SELECT p "
-            + "FROM Participant p "
-            + "WHERE p.hasDiary = true AND p.member.id = :memberId AND p.diary.content LIKE %:keyword% "
-            + "ORDER BY p.schedule.period.startDate DESC")
-    List<Participant> findAllByDiaryContentAndHasDiary(Long memberId, String keyword, Pageable pageable);
+	@Query("SELECT p "
+		+ "FROM Participant p "
+		+ "WHERE p.hasDiary = true AND p.member.id = :memberId AND p.diary.content LIKE %:keyword% "
+		+ "ORDER BY p.schedule.period.startDate DESC")
+	List<Participant> findAllByDiaryContentAndHasDiary(@Param("memberId") Long memberId,
+		@Param("keyword") String keyword, Pageable pageable);
 
-    @Query("SELECT p "
-            + "FROM Participant p "
-            + "WHERE p.hasDiary = true AND p.member.id = :memberId AND p.schedule.participantNicknames LIKE %:keyword% "
-            + "ORDER BY p.schedule.period.startDate DESC")
-    List<Participant> findAllByMemberAndHasDiary(Long memberId, String keyword, Pageable pageable);
+	@Query("SELECT p "
+		+ "FROM Participant p "
+		+ "WHERE p.hasDiary = true AND p.member.id = :memberId AND p.schedule.participantNicknames LIKE %:keyword% "
+		+ "ORDER BY p.schedule.period.startDate DESC")
+	List<Participant> findAllByMemberAndHasDiary(@Param("memberId") Long memberId, @Param("keyword") String keyword,
+		Pageable pageable);
+
+	@Query("SELECT p "
+		+ "FROM Participant p "
+		+ "WHERE p.hasDiary = true "
+		+ "AND p.member.id = :memberId "
+		+ "AND p.schedule.period.startDate BETWEEN :startDate AND :endDate")
+	List<Participant> findAllByMonthAndHasDiary(@Param("memberId") Long memberId,
+		@Param("startDate") LocalDate startDate,
+		@Param("endDate") LocalDate endDate);
 }
+

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -107,7 +107,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 		+ "WHERE p.hasDiary = true "
 		+ "AND p.member.id = :memberId "
 		+ "AND p.schedule.period.startDate BETWEEN :startDate AND :endDate")
-	List<Participant> findAllByMonthAndHasDiary(@Param("memberId") Long memberId,
+	List<Participant> findAllByDateRangeAndHasDiary(@Param("memberId") Long memberId,
 		@Param("startDate") LocalDateTime startDate,
 		@Param("endDate") LocalDateTime endDate);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -1,6 +1,5 @@
 package com.namo.spring.db.mysql.domains.schedule.repository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -109,7 +108,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 		+ "AND p.member.id = :memberId "
 		+ "AND p.schedule.period.startDate BETWEEN :startDate AND :endDate")
 	List<Participant> findAllByMonthAndHasDiary(@Param("memberId") Long memberId,
-		@Param("startDate") LocalDate startDate,
-		@Param("endDate") LocalDate endDate);
+		@Param("startDate") LocalDateTime startDate,
+		@Param("endDate") LocalDateTime endDate);
 }
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
@@ -1,6 +1,5 @@
 package com.namo.spring.db.mysql.domains.schedule.service;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -104,7 +103,8 @@ public class ParticipantService {
 		return participantRepository.findAllByMemberAndHasDiary(memberId, keyword, pageable);
 	}
 
-	public List<Participant> readParticipantHasDiaryByMonth(Long memberId, LocalDate startDate, LocalDate endDate) {
+	public List<Participant> readParticipantHasDiaryByMonth(Long memberId, LocalDateTime startDate,
+		LocalDateTime endDate) {
 		return participantRepository.findAllByMonthAndHasDiary(memberId, startDate, endDate);
 	}
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
@@ -103,8 +103,8 @@ public class ParticipantService {
 		return participantRepository.findAllByMemberAndHasDiary(memberId, keyword, pageable);
 	}
 
-	public List<Participant> readParticipantHasDiaryByMonth(Long memberId, LocalDateTime startDate,
+	public List<Participant> readParticipantHasDiaryByDateRange(Long memberId, LocalDateTime startDate,
 		LocalDateTime endDate) {
-		return participantRepository.findAllByMonthAndHasDiary(memberId, startDate, endDate);
+		return participantRepository.findAllByDateRangeAndHasDiary(memberId, startDate, endDate);
 	}
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
@@ -1,98 +1,110 @@
 package com.namo.spring.db.mysql.domains.schedule.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.namo.spring.core.common.annotation.DomainService;
 import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.repository.ParticipantRepository;
 import com.namo.spring.db.mysql.domains.schedule.type.ParticipantStatus;
 import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
 public class ParticipantService {
-    private final ParticipantRepository participantRepository;
+	private final ParticipantRepository participantRepository;
 
-    @Transactional
-    public Participant createParticipant(Participant participant) {
-        return participantRepository.save(participant);
-    }
+	@Transactional
+	public Participant createParticipant(Participant participant) {
+		return participantRepository.save(participant);
+	}
 
-    @Transactional(readOnly = true)
-    public Optional<Participant> readParticipant(Long id) {
-        return participantRepository.findById(id);
-    }
+	@Transactional(readOnly = true)
+	public Optional<Participant> readParticipant(Long id) {
+		return participantRepository.findById(id);
+	}
 
-    @Transactional(readOnly = true)
-    public Optional<Participant> readParticipantByScheduleIdAndMemberId(Long scheduleId, Long memberId) {
-        return participantRepository.findParticipantByScheduleIdAndMemberId(scheduleId, memberId);
-    }
+	@Transactional(readOnly = true)
+	public Optional<Participant> readParticipantByScheduleIdAndMemberId(Long scheduleId, Long memberId) {
+		return participantRepository.findParticipantByScheduleIdAndMemberId(scheduleId, memberId);
+	}
 
-    public List<Participant> readParticipantsByScheduleId(Long scheduleId) {
-        return participantRepository.findAllByScheduleId(scheduleId);
-    }
+	public List<Participant> readParticipantsByScheduleId(Long scheduleId) {
+		return participantRepository.findAllByScheduleId(scheduleId);
+	}
 
-    @Transactional(readOnly = true)
-    public List<Participant> readParticipantsByIdAndScheduleId(List<Long> participantIds, Long scheduleId, ParticipantStatus status) {
-        return participantRepository.findParticipantByIdAndScheduleId(participantIds, scheduleId, status);
-    }
+	@Transactional(readOnly = true)
+	public List<Participant> readParticipantsByIdAndScheduleId(List<Long> participantIds, Long scheduleId,
+		ParticipantStatus status) {
+		return participantRepository.findParticipantByIdAndScheduleId(participantIds, scheduleId, status);
+	}
 
-    @Transactional(readOnly = true)
-    public List<Participant> readScheduleParticipantSummaryByScheduleIds(Long memberId) {
-        return participantRepository.findParticipantsByMemberAndScheduleType(memberId, ScheduleType.MEETING.getValue());
-    }
+	@Transactional(readOnly = true)
+	public List<Participant> readScheduleParticipantSummaryByScheduleIds(Long memberId) {
+		return participantRepository.findParticipantsByMemberAndScheduleType(memberId, ScheduleType.MEETING.getValue());
+	}
 
-    @Transactional(readOnly = true)
-    public boolean existsByScheduleIdAndMemberId(Long scheduleId, Long memberId) {
-        return participantRepository.existsByScheduleIdAndMemberId(scheduleId, memberId);
-    }
+	@Transactional(readOnly = true)
+	public boolean existsByScheduleIdAndMemberId(Long scheduleId, Long memberId) {
+		return participantRepository.existsByScheduleIdAndMemberId(scheduleId, memberId);
+	}
 
-    @Transactional(readOnly = true)
-    public List<Participant> readParticipantsWithScheduleAndCategoryByPeriod(Long memberId, Boolean isShared, LocalDateTime startDate, LocalDateTime endDate) {
-        return participantRepository.findParticipantsWithScheduleAndCategoryByPeriod(memberId, isShared, startDate, endDate);
-    }
+	@Transactional(readOnly = true)
+	public List<Participant> readParticipantsWithScheduleAndCategoryByPeriod(Long memberId, Boolean isShared,
+		LocalDateTime startDate, LocalDateTime endDate) {
+		return participantRepository.findParticipantsWithScheduleAndCategoryByPeriod(memberId, isShared, startDate,
+			endDate);
+	}
 
-    @Transactional(readOnly = true)
-    public List<ScheduleParticipantQuery> readParticipantsWithUserAndScheduleByPeriod(List<Long> memberIds, LocalDateTime startDate, LocalDateTime endDate) {
-        return participantRepository.findParticipantsWithUserAndScheduleByPeriod(memberIds, startDate, endDate);
-    }
+	@Transactional(readOnly = true)
+	public List<ScheduleParticipantQuery> readParticipantsWithUserAndScheduleByPeriod(List<Long> memberIds,
+		LocalDateTime startDate, LocalDateTime endDate) {
+		return participantRepository.findParticipantsWithUserAndScheduleByPeriod(memberIds, startDate, endDate);
+	}
 
-    @Transactional(readOnly = true)
-    public List<Participant> readParticipantsByScheduleIdAndStatusAndType(Long scheduleId, ScheduleType type, ParticipantStatus status) {
-        return participantRepository.findParticipantsByScheduleIdAndStatusAndType(scheduleId, type.getValue(), status);
-    }
+	@Transactional(readOnly = true)
+	public List<Participant> readParticipantsByScheduleIdAndStatusAndType(Long scheduleId, ScheduleType type,
+		ParticipantStatus status) {
+		return participantRepository.findParticipantsByScheduleIdAndStatusAndType(scheduleId, type.getValue(), status);
+	}
 
-    public void deleteParticipant(Long id) {
-        participantRepository.deleteById(id);
-    }
+	public void deleteParticipant(Long id) {
+		participantRepository.deleteById(id);
+	}
 
-    public void deleteByIdIn(List<Long> Ids) {
-        participantRepository.deleteByIdIn(Ids);
-    }
+	public void deleteByIdIn(List<Long> Ids) {
+		participantRepository.deleteByIdIn(Ids);
+	}
 
-    public Optional<Participant> readParticipant(Long memberId, Long scheduleId) {
-        return participantRepository.findParticipantByMemberIdAndScheduleId(memberId, scheduleId);
-    }
+	public Optional<Participant> readParticipant(Long memberId, Long scheduleId) {
+		return participantRepository.findParticipantByMemberIdAndScheduleId(memberId, scheduleId);
+	}
 
-    public List<Participant> readParticipantsForDiary(Long memberId, Pageable pageable) {
-        return participantRepository.findAllByMemberIdAndHasDiary(memberId, pageable);
-    }
+	public List<Participant> readParticipantsHasDiary(Long memberId, Pageable pageable) {
+		return participantRepository.findAllByMemberIdAndHasDiary(memberId, pageable);
+	}
 
-    public List<Participant> readParticipantByScheduleName(Long memberId, Pageable pageable, String keyword) {
-        return participantRepository.findAllByScheduleTitleAndHasDiary(memberId, keyword, pageable);
-    }
+	public List<Participant> readParticipantHasDiaryByScheduleName(Long memberId, Pageable pageable, String keyword) {
+		return participantRepository.findAllByScheduleTitleAndHasDiary(memberId, keyword, pageable);
+	}
 
-    public List<Participant> readParticipantByDiaryContent(Long memberId, Pageable pageable, String keyword) {
-        return participantRepository.findAllByDiaryContentAndHasDiary(memberId, keyword, pageable);
-    }
+	public List<Participant> readParticipantHasDiaryByDiaryContent(Long memberId, Pageable pageable, String keyword) {
+		return participantRepository.findAllByDiaryContentAndHasDiary(memberId, keyword, pageable);
+	}
 
-    public List<Participant> readParticipantByMember(Long memberId, Pageable pageable, String keyword) {
-        return participantRepository.findAllByMemberAndHasDiary(memberId, keyword, pageable);
-    }
+	public List<Participant> readParticipantHasDiaryByMember(Long memberId, Pageable pageable, String keyword) {
+		return participantRepository.findAllByMemberAndHasDiary(memberId, keyword, pageable);
+	}
+
+	public List<Participant> readParticipantHasDiaryByMonth(Long memberId, LocalDate startDate, LocalDate endDate) {
+		return participantRepository.findAllByMonthAndHasDiary(memberId, startDate, endDate);
+	}
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [X] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

### 변경 사항

- 보관함 일기 정보에 끝나는 날짜 추가 표시
- 참여자 정보 감싸서 표기
- 카테고리 정보 표시 추가
- 주석 정보 추가

### 구현 내용
- 캘린더 상 일기 존재하는 날짜 조회할 수 있는 API 구현
- 요일별 일기 조회 API
- 클라우드 상 이미지 삭제 로직 추가

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #283
