### PR TITLE
[Feature/300] 일기(다이어리) 삭제 API 구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
@@ -138,12 +138,14 @@ public class DiaryController {
         }
     }
 
+    @Operation(summary = "기록 삭제 API", description = "입력받은 기록 ID를 삭제합니다 (본인의 기록만 삭제할 수 있습니다)")
     @DeleteMapping("/{diaryId}")
     public ResponseDto<String> deleteDiary(
             @AuthenticationPrincipal SecurityUserDetails memberInfo,
-            @Parameter(description = "삭제할 일기 ID 입니다.", example = "1")
+            @Parameter(description = "삭제할 기록 ID 입니다.", example = "1")
             @PathVariable Long diaryId
     ){
-        return ResponseDto.onSuccess("일기 삭제에 성공했습니다.");
+        diaryUseCase.deleteDiary(memberInfo.getUserId(), diaryId);
+        return ResponseDto.onSuccess("기록 삭제에 성공했습니다.");
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/DiaryController.java
@@ -6,6 +6,7 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -135,5 +136,14 @@ public class DiaryController {
         } catch (DateTimeParseException e) {
             throw new DiaryException(ErrorStatus.INVALID_FORMAT_FAILURE);
         }
+    }
+
+    @DeleteMapping("/{diaryId}")
+    public ResponseDto<String> deleteDiary(
+            @AuthenticationPrincipal SecurityUserDetails memberInfo,
+            @Parameter(description = "삭제할 일기 ID 입니다.", example = "1")
+            @PathVariable Long diaryId
+    ){
+        return ResponseDto.onSuccess("일기 삭제에 성공했습니다.");
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryImageManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryImageManageService.java
@@ -37,6 +37,11 @@ public class DiaryImageManageService {
         createDiaryImages(diary, request.getDiaryImages());
     }
 
+    public void deleteDiaryImage(Long imageId){
+        deleteFromCloud(imageId);
+        diaryImageService.deleteDiaryImage(imageId);
+    }
+
     /**
      * 클라우드(S3) 에서 이미지를 삭제하는 메서드입니다. (원본, 리사이징 본 모두 삭제)
      * !! 만약 이미지가 존재하지 않으면 로그만 남기고 Continue 됩니다.

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryImageManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryImageManageService.java
@@ -23,7 +23,6 @@ public class DiaryImageManageService {
 
     private final DiaryImageService diaryImageService;
     private final FileUtils fileUtils;
-    private final DiaryManageService diaryManageService;
 
     /**
      * 일기의 이미지를 업데이트하는 메서드입니다.

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryImageManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryImageManageService.java
@@ -23,6 +23,7 @@ public class DiaryImageManageService {
 
     private final DiaryImageService diaryImageService;
     private final FileUtils fileUtils;
+    private final DiaryManageService diaryManageService;
 
     /**
      * 일기의 이미지를 업데이트하는 메서드입니다.
@@ -37,9 +38,8 @@ public class DiaryImageManageService {
         createDiaryImages(diary, request.getDiaryImages());
     }
 
-    public void deleteDiaryImage(Long imageId){
-        deleteFromCloud(imageId);
-        diaryImageService.deleteDiaryImage(imageId);
+    public void deleteDiaryImage(Diary diary){
+        diaryImageService.deleteAll(diary);
     }
 
     /**

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
@@ -74,4 +74,14 @@ public class DiaryManageService {
         diary.update(request.getContent(), request.getEnjoyRating());
         diaryImageManageService.updateDiaryImage(diary, request);
     }
+
+    /**
+     * 다이어리를 삭제하는 메서드입니다.
+     * !! 내 일기인지 검증합니다.
+     * @param memberId
+     * @param diaryId
+     */
+    public void deleteDiary(Long memberId, Long diaryId) {
+        diaryService.deleteDiary(getMyDiary(diaryId, memberId).getId());
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
@@ -78,14 +78,14 @@ public class DiaryManageService {
 
     /**
      * 다이어리를 삭제하는 메서드입니다.
-     * !! 내 일기인지 검증합니다.
-     * @param memberId
-     * @param diaryId
+     * !! 클라우드에서 이미지를 삭제후 일기를 삭제합니다.
+     *
+     * @param diary
      */
     @Transactional
-    public void deleteDiary(Long memberId, Long diaryId) {
-        Diary myDiary = getMyDiary(diaryId, memberId);
-        myDiary.getImages().forEach(image -> diaryImageManageService.deleteDiaryImage(image.getId()));
-        diaryService.deleteDiary(myDiary);
+    public void deleteDiary(Diary diary) {
+        diary.getImages().forEach(diaryImage -> diaryImageManageService.deleteFromCloud(diaryImage.getId()));
+        diaryImageManageService.deleteDiaryImage(diary);
+        diaryService.deleteDiary(diary);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/DiaryManageService.java
@@ -1,6 +1,7 @@
 package com.namo.spring.application.external.api.record.serivce;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.namo.spring.application.external.api.record.dto.DiaryRequest;
 import com.namo.spring.core.common.code.status.ErrorStatus;
@@ -81,7 +82,10 @@ public class DiaryManageService {
      * @param memberId
      * @param diaryId
      */
+    @Transactional
     public void deleteDiary(Long memberId, Long diaryId) {
-        diaryService.deleteDiary(getMyDiary(diaryId, memberId).getId());
+        Diary myDiary = getMyDiary(diaryId, memberId);
+        myDiary.getImages().forEach(image -> diaryImageManageService.deleteDiaryImage(image.getId()));
+        diaryService.deleteDiary(myDiary);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
@@ -73,4 +73,9 @@ public class DiaryUseCase {
                 .map(DiaryResponseConverter::toDayOfDiaryDto)
                 .toList();
     }
+
+    @Transactional
+    public void deleteDiary(Long memberId, Long diaryId) {
+        diaryManageService.deleteDiary(memberId, diaryId);
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/DiaryUseCase.java
@@ -76,6 +76,7 @@ public class DiaryUseCase {
 
     @Transactional
     public void deleteDiary(Long memberId, Long diaryId) {
-        diaryManageService.deleteDiary(memberId, diaryId);
+        Diary myDiary = diaryManageService.getMyDiary(diaryId, memberId);
+        diaryManageService.deleteDiary(myDiary);
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/record/entity/Diary.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/record/entity/Diary.java
@@ -14,7 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.PostPersist;
-import jakarta.persistence.PostRemove;
+import jakarta.persistence.PreRemove;
 
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -75,8 +75,8 @@ public class Diary extends BaseTimeEntity {
         participant.diaryCreated();
     }
 
-    @PostRemove
-    public void PostRemove() {
+    @PreRemove
+    public void PreRemove() {
         participant.diaryDeleted();
     }
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/record/service/DiaryService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/record/service/DiaryService.java
@@ -30,4 +30,8 @@ public class DiaryService {
         diaryRepository.deleteById(diaryId);
     }
 
+    public void deleteDiary(Diary diary){
+        diaryRepository.delete(diary);
+    }
+
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
@@ -71,7 +71,7 @@ public class Participant extends BaseTimeEntity {
 
     private boolean hasDiary;
 
-    @OneToOne(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "participant", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private Diary diary;
 
     @Builder


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [X] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- Participant의 일기 작성여부 체크 로직 수정
  -  Diary의 PostRemove를 활용한 로직에서 영속성 문제로 DB에 반영되지 않는 문제가 발생 -> PreRemove로 해결
  - PostRemove 사용시 엔티티는 이미 데이터베이스에서 삭제되고 영속성 컨텍스트에서 분리(detached) 상태로 전환되기 때문에 반영 X
  
- Participant - Diary의 연관관계 설정 변경 orphanRemoval 제거
  - 부모(Participant)객체에 orphanRemoval 설정되어있는 오타때문에 Diary 삭제시 DB에 반영되지 않는 문제 발생 -> 제거로 해결
 
- 일기 삭제 API 구현


## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 영속성 관리에 대해 조금 더 확인할 수 있었습니다.

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #300 
