### PR TITLE
[Feature/307] 카테고리 조회 API 구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/controller/CategoryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/controller/CategoryController.java
@@ -1,0 +1,31 @@
+package com.namo.spring.application.external.api.category.controller;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.namo.spring.application.external.api.category.dto.CategoryResponse;
+import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
+import com.namo.spring.core.common.response.ResponseDto;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "카테고리", description = "카테고리 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/categories")
+public class CategoryController {
+
+    @GetMapping("")
+    public ResponseDto<List<CategoryResponse.MyCategoryInfoDto>> getCategories(
+            @AuthenticationPrincipal SecurityUserDetails memberInfo
+    ){
+        return ResponseDto.onSuccess(null);
+    }
+
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/controller/CategoryController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/controller/CategoryController.java
@@ -8,9 +8,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.namo.spring.application.external.api.category.dto.CategoryResponse;
+import com.namo.spring.application.external.api.category.usecase.CategoryUseCase;
+import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
 import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
+import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.core.common.response.ResponseDto;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
@@ -21,11 +25,15 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v2/categories")
 public class CategoryController {
 
+    private final CategoryUseCase categoryUseCase;
+
+    @Operation(summary = "나의 카테고리 목록 조회", description = "나의 카테고리 목록이 조회됩니다. 이후 뎁스의 내용도 포함됩니다.")
     @GetMapping("")
     public ResponseDto<List<CategoryResponse.MyCategoryInfoDto>> getCategories(
             @AuthenticationPrincipal SecurityUserDetails memberInfo
     ){
-        return ResponseDto.onSuccess(null);
+        return ResponseDto.onSuccess(categoryUseCase
+                .getMyCategoryList(memberInfo.getUserId()));
     }
 
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/converter/CategoryConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/converter/CategoryConverter.java
@@ -1,0 +1,19 @@
+package com.namo.spring.application.external.api.category.converter;
+
+import static com.namo.spring.db.mysql.domains.category.type.CategoryType.*;
+
+import com.namo.spring.application.external.api.category.dto.CategoryResponse;
+import com.namo.spring.db.mysql.domains.category.entity.Category;
+
+public class CategoryConverter {
+
+    public static CategoryResponse.MyCategoryInfoDto toMyCategoryInfoDto(Category category){
+        return CategoryResponse.MyCategoryInfoDto.builder()
+                .categoryId(category.getId())
+                .categoryName(category.getName())
+                .isBaseCategory(!category.getType().equals(COMMON))
+                .isShared(category.isShared())
+                .paletteId(category.getPalette().getId())
+                .build();
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/dto/CategoryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/dto/CategoryResponse.java
@@ -17,6 +17,6 @@ public class CategoryResponse {
         private String categoryName;
         private Long paletteId;
         private boolean isBaseCategory;
-        private boolean isVisible;
+        private boolean isShared;
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/dto/CategoryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/dto/CategoryResponse.java
@@ -1,0 +1,22 @@
+package com.namo.spring.application.external.api.category.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class CategoryResponse {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "카테고리 조회 DTO")
+    public static class MyCategoryInfoDto{
+        private Long categoryId;
+        private String categoryName;
+        private Long paletteId;
+        private boolean isBaseCategory;
+        private boolean isVisible;
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/service/CategoryManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/service/CategoryManageService.java
@@ -1,0 +1,21 @@
+package com.namo.spring.application.external.api.category.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.namo.spring.db.mysql.domains.category.entity.Category;
+import com.namo.spring.db.mysql.domains.category.service.CategoryService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryManageService {
+
+    private final CategoryService categoryService;
+
+    public List<Category> getMyCategories(Long memberId){
+        return categoryService.readCategoriesByMemberId(memberId);
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/usecase/CategoryUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/usecase/CategoryUseCase.java
@@ -1,0 +1,29 @@
+package com.namo.spring.application.external.api.category.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.namo.spring.application.external.api.category.converter.CategoryConverter;
+import com.namo.spring.application.external.api.category.dto.CategoryResponse;
+import com.namo.spring.application.external.api.category.service.CategoryManageService;
+import com.namo.spring.db.mysql.domains.category.entity.Category;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryUseCase {
+
+    private final CategoryManageService categoryManageService;
+
+    @Transactional(readOnly = true)
+    public List<CategoryResponse.MyCategoryInfoDto> getMyCategoryList(Long memberId){
+        List<Category> myCategories = categoryManageService.getMyCategories(memberId);
+        return myCategories.stream()
+                .map(CategoryConverter::toMyCategoryInfoDto)
+                .toList();
+    }
+
+}

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/category/repository/CategoryRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/category/repository/CategoryRepository.java
@@ -1,5 +1,6 @@
 package com.namo.spring.db.mysql.domains.category.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     @Query("select c from Category c join c.member where c.member= :member and c.type = '2'")
     Optional<Category> findMeetingCategoryByMember(@Param("member") Member member);
+
+    List<Category> findCategoryByMemberId(Long memberId);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/category/service/CategoryService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/category/service/CategoryService.java
@@ -1,5 +1,6 @@
 package com.namo.spring.db.mysql.domains.category.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.transaction.annotation.Transactional;
@@ -55,6 +56,10 @@ public class CategoryService {
     @Transactional
     public void deleteCategory(Long categoryId) {
         categoryRepository.deleteById(categoryId);
+    }
+
+    public List<Category> readCategoriesByMemberId(Long memberId){
+        return categoryRepository.findCategoryByMemberId(memberId);
     }
 
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 나의 카테고리 목록을 조회하는 API가 추가되었습니다.

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 색상 값의 저장위치

## 첨부 자료

- 아래 두개 화면을 위한 API

<img width="279" alt="image" src="https://github.com/user-attachments/assets/095cd4fe-37c5-4b1e-af5a-7b7701418528">
<img width="492" alt="image" src="https://github.com/user-attachments/assets/b82bed6b-8ee0-4e94-9980-c3fdb840eb47">


## 관련 이슈

-  #300 
