### PR TITLE
[Feature/297] 요구 사항 변경에 따른 custom 일정 정보 적용 및 수정 API구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/controller/GuestController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/controller/GuestController.java
@@ -46,7 +46,7 @@ public class GuestController {
             ErrorStatus.NOT_FOUND_COLOR
     })
     @PostMapping(path = "/invitations")
-    public ResponseDto<GuestParticipantResponse.PostGuestParticipantDto> guestMeetingAccess(
+    public ResponseDto<GuestParticipantResponse.PostGuestParticipantInfoDto> guestMeetingAccess(
             @Parameter(description = "참여 코드, 웹 링크의 code 파라미터를 입력합니다.") @RequestParam String code,
             @Valid @RequestBody GuestParticipantRequest.PostGuestParticipantDto dto) {
         return ResponseDto.onSuccess(guestUsecase.createOrValidateGuest(dto, code));

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/converter/GuestMeetingResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/converter/GuestMeetingResponseConverter.java
@@ -26,7 +26,7 @@ public class GuestMeetingResponseConverter {
             Schedule schedule, List<ScheduleParticipantQuery> participant, Schedule curSchedule) {
         return GuestMeetingResponse.GetMonthlyMeetingParticipantScheduleDto.builder()
                 .scheduleId(schedule.getId())
-                .name(schedule.getTitle())
+                .title(schedule.getTitle())
                 .startDate(DateUtil.toSeconds(schedule.getPeriod().getStartDate()))
                 .endDate(DateUtil.toSeconds(schedule.getPeriod().getEndDate()))
                 .interval(schedule.getPeriod().getDayInterval())
@@ -35,16 +35,16 @@ public class GuestMeetingResponseConverter {
                 .build();
     }
 
-    private static List<GuestMeetingResponse.UserParticipantDto> toUserParticipantDtos(
+    private static List<GuestMeetingResponse.ParticipantDto> toUserParticipantDtos(
             List<ScheduleParticipantQuery> participant) {
         return participant.stream()
                 .map(GuestMeetingResponseConverter::toUserParticipantDto)
                 .collect(Collectors.toList());
     }
 
-    private static GuestMeetingResponse.UserParticipantDto toUserParticipantDto(ScheduleParticipantQuery
+    private static GuestMeetingResponse.ParticipantDto toUserParticipantDto(ScheduleParticipantQuery
             participant) {
-        return GuestMeetingResponse.UserParticipantDto.builder()
+        return GuestMeetingResponse.ParticipantDto.builder()
                 .participantId(participant.getParticipantId())
                 .nickname(participant.getNickname())
                 .colorId(participant.getParticipantPaletteId())

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/converter/GuestParticipantResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/converter/GuestParticipantResponseConverter.java
@@ -5,8 +5,8 @@ import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 
 public class GuestParticipantResponseConverter {
 
-    public static GuestParticipantResponse.PostGuestParticipantDto toPostGuestParticipantDto(Participant participant) {
-        return GuestParticipantResponse.PostGuestParticipantDto.builder()
+    public static GuestParticipantResponse.PostGuestParticipantInfoDto toPostGuestParticipantDto(Participant participant) {
+        return GuestParticipantResponse.PostGuestParticipantInfoDto.builder()
                 .nickname(participant.getAnonymous().getNickname())
                 .tag(participant.getAnonymous().getTag())
                 .participantId(participant.getId())

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/dto/GuestMeetingResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/dto/GuestMeetingResponse.java
@@ -18,7 +18,7 @@ public class GuestMeetingResponse {
         @Schema(description = "일정 ID")
         private Long scheduleId;
         @Schema(description = "일정 이름", example = "나모 정기 회의")
-        private String name;
+        private String title;
         @Schema(description = "일정 시작일, unix 타임스탬프 형식")
         private Long startDate;
         @Schema(description = "일정 종료일, unix 타임스탬프 형식")
@@ -26,7 +26,7 @@ public class GuestMeetingResponse {
         @Schema(description = "시작일과 종료일 차이")
         private Long interval;
         @Schema(description = "일정 참여자 목록")
-        private List<GuestMeetingResponse.UserParticipantDto> participants;
+        private List<ParticipantDto> participants;
         @Schema(description = "현재 조회하는 모임 일정인지의 여부")
         private Boolean isCurMeetingSchedule = false;
     }
@@ -35,7 +35,7 @@ public class GuestMeetingResponse {
     @Getter
     @Builder
     @Schema(title = "모임 일정 조회 - 일정의 참여자 목록")
-    public static class UserParticipantDto {
+    public static class ParticipantDto {
         @Schema(description = "참여자 ID")
         private Long participantId;
         @Schema(description = "닉네임")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/dto/GuestParticipantResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/dto/GuestParticipantResponse.java
@@ -12,7 +12,7 @@ public class GuestParticipantResponse {
     @Getter
     @Builder
     @Schema(title = "게스트 모임 가입/로그인 응답 DTO")
-    public static class PostGuestParticipantDto {
+    public static class PostGuestParticipantInfoDto {
         private String nickname;
         private String tag;
         private Long participantId;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/service/GuestManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/service/GuestManageService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.namo.spring.application.external.global.config.properties.WebUrlConfig;
 import org.springframework.stereotype.Service;
 
 import com.namo.spring.application.external.api.guest.dto.GuestParticipantRequest;
@@ -39,6 +40,7 @@ public class GuestManageService {
     private final ParticipantService participantService;
     private final ParticipantMaker participantMaker;
     private final TagGenerator tagGenerator;
+    private final WebUrlConfig webUrlConfig;
 
     public Anonymous createAnonymous(GuestParticipantRequest.PostGuestParticipantDto dto, Schedule schedule,
             String code, String tag) {
@@ -98,13 +100,17 @@ public class GuestManageService {
                 .orElseGet(() -> createGuest(dto, schedule, code));
     }
 
+    public String generateInvitationUrl(Long scheduleId){
+        return webUrlConfig.getInvitation()+generateInviteCode(scheduleId);
+    }
+
     /**
      * 일정 ID 값을 담은 참여 코드를 생성합니다.
      *
      * @param scheduleId
      * @return 참여 코드
      */
-    public String generateInviteCode(Long scheduleId) {
+    private String generateInviteCode(Long scheduleId) {
         List<String> existCodes = anonymousService.readAllInviteCodes()
                 .stream()
                 .map(AnonymousInviteCodeQuery::getCode)

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/usecase/GuestUsecase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/usecase/GuestUsecase.java
@@ -31,7 +31,7 @@ public class GuestUsecase {
     private final GuestManageService guestManageService;
 
     @Transactional
-    public GuestParticipantResponse.PostGuestParticipantDto createOrValidateGuest(
+    public GuestParticipantResponse.PostGuestParticipantInfoDto createOrValidateGuest(
             GuestParticipantRequest.PostGuestParticipantDto dto, String code) {
         Long scheduleId = guestManageService.decodeInviteCode(code);
         Schedule schedule = scheduleManageService.getMeetingSchedule(scheduleId);

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
@@ -38,7 +38,7 @@ public class DiaryResponseConverter {
                 .scheduleEndDate(participant.getSchedule().getPeriod().getEndDate())
                 .categoryInfo(toCategoryInfoDto(participant.getCategory()))
                 .scheduleId(participant.getSchedule().getId())
-                .title(participant.getSchedule().getTitle())
+                .title(participant.getScheduleTitle())
                 .diarySummary(toDiarySummaryDto(participant.getDiary()))
                 .scheduleType(participant.getSchedule().getScheduleType())
                 .participantInfo(toParticipantInfo(participant.getSchedule()))
@@ -91,7 +91,7 @@ public class DiaryResponseConverter {
                 .categoryInfo(toCategoryInfoDto(participant.getCategory()))
                 .scheduleStartDate(participant.getSchedule().getPeriod().getStartDate())
                 .scheduleEndDate(participant.getSchedule().getPeriod().getEndDate())
-                .scheduleTitle(participant.getSchedule().getTitle())
+                .scheduleTitle(participant.getScheduleTitle())
                 .diaryId(participant.getDiary().getId())
                 .participantInfo(toParticipantInfo(participant.getSchedule()))
                 .build();

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/api/MeetingScheduleApi.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/api/MeetingScheduleApi.java
@@ -99,7 +99,7 @@ public interface MeetingScheduleApi {
             @Parameter(description = "모임 일정 ID") @PathVariable Long meetingScheduleId,
             @AuthenticationPrincipal SecurityUserDetails memberInfo);
 
-    @Operation(summary = "게스트 초대용 링크 조회", description = "게스트 초대용 링크를 조회합니다. 초대 인원이 최대인 경우에 조회되지 않습니다.")
+    @Operation(summary = "게스트 초대용 링크 조회", description = "게스트 초대용 링크를 조회합니다. 초대된 인원이 최대인 경우에 조회되지 않습니다.")
     @ApiErrorCodes(value = {
             ErrorStatus.NOT_SCHEDULE_OWNER,
             ErrorStatus.NOT_SCHEDULE_PARTICIPANT,
@@ -107,7 +107,7 @@ public interface MeetingScheduleApi {
             ErrorStatus.NOT_MEETING_SCHEDULE,
             ErrorStatus.INVALID_MEETING_PARTICIPANT_COUNT
     })
-    ResponseDto<String> getGuestInviteCode(
+    ResponseDto<String> getGuestInvitationUrl(
             @Parameter(description = "모임 일정 ID") @PathVariable Long meetingScheduleId,
             @AuthenticationPrincipal SecurityUserDetails memberInfo
     );

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/api/MeetingScheduleApi.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/api/MeetingScheduleApi.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleResponse;
@@ -20,9 +19,6 @@ import com.namo.spring.core.common.response.ResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "모임 일정", description = "모임 일정 관련 API")
@@ -35,14 +31,12 @@ public interface MeetingScheduleApi {
             ErrorStatus.INVALID_MEETING_PARTICIPANT_COUNT,
             ErrorStatus.NOT_FOUND_FRIENDSHIP_FAILURE,
             ErrorStatus.INVALID_DATE,
-            ErrorStatus.S3_UPLOAD_FAILURE,
             ErrorStatus.NOT_FOUND_CATEGORY_FAILURE,
             ErrorStatus.NOT_FOUND_PALETTE_FAILURE,
 
     })
     ResponseDto<Long> createMeetingSchedule(
             @Parameter(description = "생성 요청 dto") @Valid @RequestPart MeetingScheduleRequest.PostMeetingScheduleDto dto,
-            @Parameter(description = "모임 일정 프로필 이미지") @RequestPart(required = false) MultipartFile image,
             @AuthenticationPrincipal SecurityUserDetails member);
 
     @Operation(summary = "모임 일정 목록 조회", description = "모임 일정 목록을 조회합니다.")
@@ -90,6 +84,12 @@ public interface MeetingScheduleApi {
     ResponseDto<String> updateMeetingSchedule(
             @Parameter(description = "모임 일정 ID") @PathVariable Long meetingScheduleId,
             @Parameter(description = "수정 요청 dto") @RequestBody @Valid MeetingScheduleRequest.PatchMeetingScheduleDto dto,
+            @AuthenticationPrincipal SecurityUserDetails memberInfo);
+
+    @Operation(summary = "모임 일정 수정", description = "모임 일정을 수정합니다. 수정 권한은 모임의 방장에게만 있습니다.")
+    ResponseDto<String> updateMeetingScheduleProfile(
+            @Parameter(description = "모임 일정 ID") @PathVariable Long meetingScheduleId,
+            @Parameter(description = "수정 요청 dto") @RequestBody @Valid MeetingScheduleRequest.PatchMeetingScheduleProfileDto dto,
             @AuthenticationPrincipal SecurityUserDetails memberInfo);
 
     @Operation(summary = "모임 상세 조회", description = "모임 일정을 상세 조회합니다.")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/api/MeetingScheduleApi.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/api/MeetingScheduleApi.java
@@ -5,10 +5,7 @@ import java.util.List;
 import jakarta.validation.Valid;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.*;
 
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleResponse;
@@ -86,7 +83,7 @@ public interface MeetingScheduleApi {
             @Parameter(description = "수정 요청 dto") @RequestBody @Valid MeetingScheduleRequest.PatchMeetingScheduleDto dto,
             @AuthenticationPrincipal SecurityUserDetails memberInfo);
 
-    @Operation(summary = "모임 일정 수정", description = "모임 일정을 수정합니다. 수정 권한은 모임의 방장에게만 있습니다.")
+    @Operation(summary = "모임 일정 프로필 수정", description = "모임 일정의 이미지와 제목을 커스텀합니다.")
     ResponseDto<String> updateMeetingScheduleProfile(
             @Parameter(description = "모임 일정 ID") @PathVariable Long meetingScheduleId,
             @Parameter(description = "수정 요청 dto") @RequestBody @Valid MeetingScheduleRequest.PatchMeetingScheduleProfileDto dto,
@@ -101,4 +98,17 @@ public interface MeetingScheduleApi {
     ResponseDto<MeetingScheduleResponse.GetMeetingScheduleDto> getMeetingSchedule(
             @Parameter(description = "모임 일정 ID") @PathVariable Long meetingScheduleId,
             @AuthenticationPrincipal SecurityUserDetails memberInfo);
+
+    @Operation(summary = "게스트 초대용 링크 조회", description = "게스트 초대용 링크를 조회합니다. 초대 인원이 최대인 경우에 조회되지 않습니다.")
+    @ApiErrorCodes(value = {
+            ErrorStatus.NOT_SCHEDULE_OWNER,
+            ErrorStatus.NOT_SCHEDULE_PARTICIPANT,
+            ErrorStatus.NOT_FOUND_SCHEDULE_FAILURE,
+            ErrorStatus.NOT_MEETING_SCHEDULE,
+            ErrorStatus.INVALID_MEETING_PARTICIPANT_COUNT
+    })
+    ResponseDto<String> getGuestInviteCode(
+            @Parameter(description = "모임 일정 ID") @PathVariable Long meetingScheduleId,
+            @AuthenticationPrincipal SecurityUserDetails memberInfo
+    );
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/MeetingScheduleController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/MeetingScheduleController.java
@@ -2,8 +2,6 @@ package com.namo.spring.application.external.api.schedule.controller;
 
 import java.util.List;
 
-import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
-import com.namo.spring.core.common.code.status.ErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
@@ -108,10 +106,10 @@ public class MeetingScheduleController implements MeetingScheduleApi {
 
     @Operation(summary = "게스트 초대용 링크 조회", description = "게스트 초대용 링크를 조회합니다. 초대 인원이 최대인 경우에 조회되지 않습니다.")
     @GetMapping(path = "/{meetingScheduleId}/invitations")
-    public ResponseDto<String> getGuestInviteCode(
-            @Parameter(description = "모임 일정 ID") @PathVariable Long meetingScheduleId,
+    public ResponseDto<String> getGuestInvitationUrl(
+            @PathVariable Long meetingScheduleId,
             @AuthenticationPrincipal SecurityUserDetails memberInfo
     ) {
-        return ResponseDto.onSuccess(meetingScheduleUsecase.getGuestInviteCode(meetingScheduleId, memberInfo));
+        return ResponseDto.onSuccess(meetingScheduleUsecase.getGuestInvitationUrl(meetingScheduleId, memberInfo));
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/MeetingScheduleController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/MeetingScheduleController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.namo.spring.application.external.api.schedule.api.MeetingScheduleApi;
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
@@ -47,9 +46,8 @@ public class MeetingScheduleController implements MeetingScheduleApi {
     @PostMapping(path = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseDto<Long> createMeetingSchedule(
             @Valid @RequestPart MeetingScheduleRequest.PostMeetingScheduleDto dto,
-            @RequestPart(required = false) MultipartFile image,
             @AuthenticationPrincipal SecurityUserDetails memberInfo) {
-        return ResponseDto.onSuccess(meetingScheduleUsecase.createMeetingSchedule(dto, image, memberInfo));
+        return ResponseDto.onSuccess(meetingScheduleUsecase.createMeetingSchedule(dto, memberInfo));
     }
 
     @Operation(summary = "모임 일정 목록 조회", description = "모임 일정 목록을 조회합니다.")
@@ -98,6 +96,16 @@ public class MeetingScheduleController implements MeetingScheduleApi {
             @AuthenticationPrincipal SecurityUserDetails memberInfo) {
         meetingScheduleUsecase.updateMeetingSchedule(dto, meetingScheduleId, memberInfo);
         return ResponseDto.onSuccess("모임 일정 수정 성공");
+    }
+
+    @Operation(summary = "모임 일정 프로필 수정", description = "모임 일정의 이미지와 제목을 커스텀합니다.")
+    @PatchMapping(path = "/{meetingScheduleId}/profile")
+    public ResponseDto<String> updateMeetingScheduleProfile(
+            @PathVariable Long meetingScheduleId,
+            @RequestBody @Valid MeetingScheduleRequest.PatchMeetingScheduleProfileDto dto,
+            @AuthenticationPrincipal SecurityUserDetails memberInfo) {
+        meetingScheduleUsecase.updateMeetingScheduleProfile(dto, meetingScheduleId, memberInfo);
+        return ResponseDto.onSuccess("모임 일정 프로필 수정 성공");
     }
 
     @Operation(summary = "게스트 초대용 링크 조회 API", description = "게스트 초대용 링크를 조회합니다. 초대 인원이 최대인 경우에 조회되지 않습니다.")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/MeetingScheduleController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/MeetingScheduleController.java
@@ -106,15 +106,8 @@ public class MeetingScheduleController implements MeetingScheduleApi {
         return ResponseDto.onSuccess("모임 일정 프로필 수정 성공");
     }
 
-    @Operation(summary = "게스트 초대용 링크 조회 API", description = "게스트 초대용 링크를 조회합니다. 초대 인원이 최대인 경우에 조회되지 않습니다.")
+    @Operation(summary = "게스트 초대용 링크 조회", description = "게스트 초대용 링크를 조회합니다. 초대 인원이 최대인 경우에 조회되지 않습니다.")
     @GetMapping(path = "/{meetingScheduleId}/invitations")
-    @ApiErrorCodes(value = {
-            ErrorStatus.NOT_SCHEDULE_OWNER,
-            ErrorStatus.NOT_SCHEDULE_PARTICIPANT,
-            ErrorStatus.NOT_FOUND_SCHEDULE_FAILURE,
-            ErrorStatus.NOT_MEETING_SCHEDULE,
-            ErrorStatus.INVALID_MEETING_PARTICIPANT_COUNT
-    })
     public ResponseDto<String> getGuestInviteCode(
             @Parameter(description = "모임 일정 ID") @PathVariable Long meetingScheduleId,
             @AuthenticationPrincipal SecurityUserDetails memberInfo

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/MeetingScheduleController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/MeetingScheduleController.java
@@ -40,9 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MeetingScheduleController implements MeetingScheduleApi {
     private final MeetingScheduleUsecase meetingScheduleUsecase;
 
-    /**
-     * 모임 일정 생성 API
-     */
+    @Operation(summary = "모임 일정 생성", description = "모임 일정을 생성합니다. 요청 성공 시 모임 일정 ID를 전송합니다.")
     @PostMapping(path = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseDto<Long> createMeetingSchedule(
             @Valid @RequestPart MeetingScheduleRequest.PostMeetingScheduleDto dto,

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleResponse;
 import com.namo.spring.core.common.utils.DateUtil;
 import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
+import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.type.Location;
@@ -20,18 +21,18 @@ public class MeetingScheduleResponseConverter {
     }
 
     public static List<MeetingScheduleResponse.GetMeetingScheduleSummaryDto> toGetMeetingScheduleSummaryDtos(
-            List<Schedule> schedules) {
+            List<ScheduleSummaryQuery> schedules) {
         return schedules.stream()
                 .map(MeetingScheduleResponseConverter::toGetMeetingScheduleSummaryDto)
                 .collect(Collectors.toList());
     }
 
     public static MeetingScheduleResponse.GetMeetingScheduleSummaryDto toGetMeetingScheduleSummaryDto(
-            Schedule schedule) {
+            ScheduleSummaryQuery schedule) {
         return MeetingScheduleResponse.GetMeetingScheduleSummaryDto.builder()
-                .meetingScheduleId(schedule.getId())
+                .meetingScheduleId(schedule.getMeetingScheduleId())
                 .title(schedule.getTitle())
-                .startDate(DateUtil.toSeconds(schedule.getPeriod().getStartDate()))
+                .startDate(DateUtil.toSeconds(schedule.getStartDate()))
                 .imageUrl(schedule.getImageUrl())
                 .participantCount(schedule.getParticipantCount())
                 .participantNicknames(schedule.getParticipantNicknames())

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
@@ -39,8 +39,8 @@ public class MeetingScheduleResponseConverter {
 
     }
 
-    public static List<MeetingScheduleResponse.GetMonthlyMembersScheduleDto> toGetMonthlyParticipantScheduleDtos(
-            List<ScheduleParticipantQuery> participantsWithSchedule, List<Long> participantIds, Long ownerId) {
+    public static List<MeetingScheduleResponse.GetMonthlyMembersScheduleDto> toGetMonthlyMembersScheduleDtos(
+            List<ScheduleParticipantQuery> participantsWithSchedule, Long ownerId) {
         Map<Long, List<ScheduleParticipantQuery>> scheduleIdAndParticipant
                 = participantsWithSchedule.stream()
                 // 다른 유저의 일정일 경우 공유 여부로 필터링
@@ -53,19 +53,24 @@ public class MeetingScheduleResponseConverter {
                 .collect(Collectors.groupingBy(participant -> participant.getSchedule().getId()));
         return scheduleIdAndParticipant.entrySet().stream()
                 .map(entry -> toGetMonthlyParticipantScheduleDto(entry.getValue().get(0).getSchedule(),
-                        entry.getValue()))
+                        entry.getValue(), ownerId))
                 .collect(Collectors.toList());
     }
 
     public static MeetingScheduleResponse.GetMonthlyMembersScheduleDto toGetMonthlyParticipantScheduleDto(
-            Schedule schedule, List<ScheduleParticipantQuery> participant) {
+            Schedule schedule, List<ScheduleParticipantQuery> participants, Long curMemberId) {
+        String title = participants.stream()
+                .filter(participant -> participant.getMemberId().equals(curMemberId))
+                .findFirst()
+                .map(ScheduleParticipantQuery::getCustomTitle)
+                .orElse(schedule.getTitle());
         return MeetingScheduleResponse.GetMonthlyMembersScheduleDto.builder()
                 .scheduleId(schedule.getId())
-                .name(schedule.getTitle())
+                .title(title)
                 .startDate(DateUtil.toSeconds(schedule.getPeriod().getStartDate()))
                 .endDate(DateUtil.toSeconds(schedule.getPeriod().getEndDate()))
                 .interval(schedule.getPeriod().getDayInterval())
-                .participants(toMemberParticipantDtos(participant))
+                .participants(toMemberParticipantDtos(participants))
                 .build();
     }
 
@@ -86,25 +91,30 @@ public class MeetingScheduleResponseConverter {
     }
 
     public static List<MeetingScheduleResponse.GetMonthlyMeetingParticipantScheduleDto> toGetMonthlyMeetingParticipantScheduleDtos(
-            List<ScheduleParticipantQuery> participantsWithSchedule, Schedule curSchedule) {
+            List<ScheduleParticipantQuery> participantsWithSchedule, Schedule curSchedule, Long curMemberId) {
         Map<Long, List<ScheduleParticipantQuery>> scheduleIdAndParticipant
                 = participantsWithSchedule.stream()
                 .collect(Collectors.groupingBy(participant -> participant.getSchedule().getId()));
         return scheduleIdAndParticipant.entrySet().stream()
                 .map(entry -> toGetMonthlyMeetingParticipantScheduleDto(entry.getValue().get(0).getSchedule(),
-                        entry.getValue(), curSchedule))
+                        entry.getValue(), curSchedule, curMemberId))
                 .collect(Collectors.toList());
     }
 
     public static MeetingScheduleResponse.GetMonthlyMeetingParticipantScheduleDto toGetMonthlyMeetingParticipantScheduleDto(
-            Schedule schedule, List<ScheduleParticipantQuery> participant, Schedule curSchedule) {
+            Schedule schedule, List<ScheduleParticipantQuery> participants, Schedule curSchedule, Long curMemberId) {
+        String title = participants.stream()
+                .filter(participant -> participant.getMemberId().equals(curMemberId))
+                .findFirst()
+                .map(ScheduleParticipantQuery::getCustomTitle)
+                .orElse(schedule.getTitle());
         return MeetingScheduleResponse.GetMonthlyMeetingParticipantScheduleDto.builder()
                 .scheduleId(schedule.getId())
-                .name(schedule.getTitle())
+                .title(title)
                 .startDate(DateUtil.toSeconds(schedule.getPeriod().getStartDate()))
                 .endDate(DateUtil.toSeconds(schedule.getPeriod().getEndDate()))
                 .interval(schedule.getPeriod().getDayInterval())
-                .participants(toUserParticipantDtos(participant))
+                .participants(toUserParticipantDtos(participants))
                 .isCurMeetingSchedule(schedule.getId().equals(curSchedule.getId()))
                 .build();
     }
@@ -127,11 +137,14 @@ public class MeetingScheduleResponseConverter {
     }
 
     public static MeetingScheduleResponse.GetMeetingScheduleDto toGetMeetingScheduleDto(Schedule
-            schedule, List<Participant> participants) {
+            schedule, List<Participant> participants, Long curMemberId) {
+        Participant customScheduleInfo = participants.stream()
+                .filter(participant -> participant.getMember().getId().equals(curMemberId))
+                .findFirst().get();
         return MeetingScheduleResponse.GetMeetingScheduleDto.builder()
                 .scheduleId(schedule.getId())
-                .name(schedule.getTitle())
-                .imageUrl(schedule.getImageUrl())
+                .title(customScheduleInfo.getCustomTitle())
+                .imageUrl(customScheduleInfo.getCustomImage())
                 .startDate(DateUtil.toSeconds(schedule.getPeriod().getStartDate()))
                 .endDate(DateUtil.toSeconds(schedule.getPeriod().getEndDate()))
                 .interval(schedule.getPeriod().getDayInterval())

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
@@ -62,9 +62,9 @@ public class MeetingScheduleResponseConverter {
             Schedule schedule, List<ScheduleParticipantQuery> participants, Long curMemberId) {
         String title = participants.stream()
                 .filter(participant -> participant.getMemberId().equals(curMemberId))
-                .findFirst()
-                .map(ScheduleParticipantQuery::getCustomTitle)
-                .orElse(schedule.getTitle());
+                        .findFirst()
+                        .map(ScheduleParticipantQuery::getCustomTitle)
+                        .orElse(schedule.getTitle());
         return MeetingScheduleResponse.GetMonthlyMembersScheduleDto.builder()
                 .scheduleId(schedule.getId())
                 .title(title)
@@ -128,7 +128,7 @@ public class MeetingScheduleResponseConverter {
     }
 
     private static MeetingScheduleResponse.UserParticipantDto toUserParticipantDto(ScheduleParticipantQuery
-            participant) {
+                                                                                           participant) {
         return MeetingScheduleResponse.UserParticipantDto.builder()
                 .participantId(participant.getParticipantId())
                 .userId(participant.getMemberId())
@@ -137,8 +137,7 @@ public class MeetingScheduleResponseConverter {
                 .build();
     }
 
-    public static MeetingScheduleResponse.GetMeetingScheduleDto toGetMeetingScheduleDto(Schedule
-            schedule, List<Participant> participants, Long curMemberId) {
+    public static MeetingScheduleResponse.GetMeetingScheduleDto toGetMeetingScheduleDto(Schedule schedule, List<Participant> participants, Long curMemberId) {
         Participant customScheduleInfo = participants.stream()
                 .filter(participant -> participant.getMember().getId().equals(curMemberId))
                 .findFirst().get();
@@ -171,7 +170,7 @@ public class MeetingScheduleResponseConverter {
     }
 
     private static MeetingScheduleResponse.UserParticipantDetailDto toUserParticipantDetailDto(Participant
-            participant) {
+                                                                                                       participant) {
         return MeetingScheduleResponse.UserParticipantDetailDto.builder()
                 .participantId(participant.getId())
                 .userId(participant.getUser().getId())

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/PersonalScheduleResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/PersonalScheduleResponseConverter.java
@@ -40,10 +40,9 @@ public class PersonalScheduleResponseConverter {
     public static PersonalScheduleResponse.GetMonthlyScheduleDto toGetMonthlyScheduleDto(Participant participant,
             List<ScheduleNotificationQuery> notifications) {
         boolean isMeetingSchedule = participant.getSchedule().getIsMeetingSchedule();
-        String title = isMeetingSchedule ? participant.getCustomTitle() : participant.getSchedule().getTitle();
         return PersonalScheduleResponse.GetMonthlyScheduleDto.builder()
                 .scheduleId(participant.getSchedule().getId())
-                .title(title)
+                .title(participant.getScheduleTitle())
                 .categoryInfo(toCategoryDto(participant.getCategory()))
                 .startDate(DateUtil.toSeconds(participant.getSchedule().getPeriod().getStartDate()))
                 .endDate(DateUtil.toSeconds(participant.getSchedule().getPeriod().getEndDate()))

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/PersonalScheduleResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/PersonalScheduleResponseConverter.java
@@ -39,7 +39,7 @@ public class PersonalScheduleResponseConverter {
 
     public static PersonalScheduleResponse.GetMonthlyScheduleDto toGetMonthlyScheduleDto(Participant participant,
             List<ScheduleNotificationQuery> notifications) {
-        boolean isMeetingSchedule = getIsMeetingSchedule(participant.getSchedule().getScheduleType());
+        boolean isMeetingSchedule = participant.getSchedule().getIsMeetingSchedule();
         String title = isMeetingSchedule ? participant.getCustomTitle() : participant.getSchedule().getTitle();
         return PersonalScheduleResponse.GetMonthlyScheduleDto.builder()
                 .scheduleId(participant.getSchedule().getId())
@@ -118,10 +118,6 @@ public class PersonalScheduleResponseConverter {
                 .endDate(DateUtil.toSeconds(participant.getSchedule().getPeriod().getEndDate()))
                 .interval(participant.getSchedule().getPeriod().getDayInterval())
                 .build();
-    }
-
-    private static boolean getIsMeetingSchedule(int type) {
-        return type == ScheduleType.MEETING.getValue();
     }
 
     private static boolean getParticipantIsOwner(int isOwner) {

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/PersonalScheduleResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/PersonalScheduleResponseConverter.java
@@ -39,25 +39,24 @@ public class PersonalScheduleResponseConverter {
 
     public static PersonalScheduleResponse.GetMonthlyScheduleDto toGetMonthlyScheduleDto(Participant participant,
             List<ScheduleNotificationQuery> notifications) {
-        PersonalScheduleResponse.GetMonthlyScheduleDto.GetMonthlyScheduleDtoBuilder builder = PersonalScheduleResponse.GetMonthlyScheduleDto.builder()
+        boolean isMeetingSchedule = getIsMeetingSchedule(participant.getSchedule().getScheduleType());
+        String title = isMeetingSchedule ? participant.getCustomTitle() : participant.getSchedule().getTitle();
+        return PersonalScheduleResponse.GetMonthlyScheduleDto.builder()
                 .scheduleId(participant.getSchedule().getId())
-                .title(participant.getSchedule().getTitle())
+                .title(title)
                 .categoryInfo(toCategoryDto(participant.getCategory()))
                 .startDate(DateUtil.toSeconds(participant.getSchedule().getPeriod().getStartDate()))
                 .endDate(DateUtil.toSeconds(participant.getSchedule().getPeriod().getEndDate()))
                 .interval(participant.getSchedule().getPeriod().getDayInterval())
                 .locationInfo(participant.getSchedule().getLocation() != null ?
                         toLocationDto(participant.getSchedule().getLocation()) : null)
-                .isMeetingSchedule(getIsMeetingSchedule(participant.getSchedule().getScheduleType()))
+                .isMeetingSchedule(isMeetingSchedule)
                 .hasDiary(participant.isHasDiary())
                 .notificationInfo(notifications != null ?
-                        toNotificationDtos(notifications, participant.getSchedule().getPeriod().getStartDate()) : null);
-        if (getIsMeetingSchedule(participant.getSchedule().getScheduleType())) {
-            return builder
-                    .meetingInfo(toMeetingInfoDto(participant.getIsOwner(), participant.getSchedule()))
-                    .build();
-        } else
-            return builder.build();
+                        toNotificationDtos(notifications, participant.getSchedule().getPeriod().getStartDate()) : null)
+                .meetingInfo(isMeetingSchedule ?
+                        toMeetingInfoDto(participant.getIsOwner(), participant.getSchedule()) : null)
+                .build();
     }
 
     private static PersonalScheduleResponse.CategoryDto toCategoryDto(Category category) {

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/MeetingScheduleRequest.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/MeetingScheduleRequest.java
@@ -25,6 +25,8 @@ public class MeetingScheduleRequest {
         @NotBlank(message = "일정 이름은 공백일 수 없습니다.")
         @Schema(description = "모임 일정 이름", example = "나모 정기 회의")
         private String title;
+        @Schema(description = "이미지 URL, null을 입력하면 기본 이미지가 생성됩니다.", example = "https://static.namong.shop/origin/diary/image.jpg")
+        private String imageUrl;
         @NotNull(message = "일정 시작일, 종료일 정보는 필수 입니다.")
         @Schema(description = "기간 정보")
         private PeriodDto period;
@@ -70,6 +72,9 @@ public class MeetingScheduleRequest {
         @NotBlank(message = "일정 이름 입력은 필수 입니다. 수정 사항이 없을 시 원본 값을 전송합니다.")
         @Schema(description = "모임 일정 이름, 수정 사항이 없을 시 원본 값을 전송합니다.")
         private String title;
+        @NotBlank(message = "이미지 url 입력은 필수 입니다. 수정 사항이 없을 시 원본 값을 전송합니다.")
+        @Schema(description = "이미지 URL", example = "https://static.namong.shop/origin/diary/image.jpg")
+        private String imageUrl;
         @NotNull(message = "기간 입력은 필수 입니다. 수정 사항이 없을 시 원본 값을 전송합니다.")
         @Schema(description = "기간, 수정 사항이 없을 시 원본 값을 전송합니다.")
         private PeriodDto period;
@@ -82,5 +87,18 @@ public class MeetingScheduleRequest {
         @NotNull(message = "삭제할 유저가 없을 시 empty array를 전송하세요.")
         @Schema(description = "스케줄에서 삭제할 참가자 ID(participantId), 삭제할 유저가 없을 시 empty array를 전송합니다.")
         private List<Long> participantsToRemove;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Schema(title = "모임 일정 프로필 수정 요청 DTO")
+    public static class PatchMeetingScheduleProfileDto {
+        @NotBlank(message = "일정 이름 입력은 필수 입니다. 수정 사항이 없을 시 원본 값을 전송합니다.")
+        @Schema(description = "모임 일정 이름, 수정 사항이 없을 시 원본 값을 전송합니다.")
+        private String title;
+        @NotBlank(message = "이미지 url 입력은 필수 입니다. 수정 사항이 없을 시 원본 값을 전송합니다.")
+        @Schema(description = "이미지 URL", example = "https://static.namong.shop/origin/diary/image.jpg")
+        private String imageUrl;
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/MeetingScheduleResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/MeetingScheduleResponse.java
@@ -40,7 +40,7 @@ public class MeetingScheduleResponse {
         @Schema(description = "일정 ID")
         private Long scheduleId;
         @Schema(description = "일정 이름", example = "나모 정기 회의")
-        private String name;
+        private String title;
         @Schema(description = "모임 일정 이미지  url", example = "")
         private String imageUrl;
         @Schema(description = "일정 시작일, unix 타임스탬프 형식")
@@ -77,7 +77,7 @@ public class MeetingScheduleResponse {
         @Schema(description = "일정 ID")
         private Long scheduleId;
         @Schema(description = "일정 이름", example = "나모 정기 회의")
-        private String name;
+        private String title;
         @Schema(description = "일정 시작일, unix 타임스탬프 형식")
         private Long startDate;
         @Schema(description = "일정 종료일, unix 타임스탬프 형식")
@@ -96,7 +96,7 @@ public class MeetingScheduleResponse {
         @Schema(description = "일정 ID")
         private Long scheduleId;
         @Schema(description = "일정 이름", example = "나모 정기 회의")
-        private String name;
+        private String title;
         @Schema(description = "일정 시작일, unix 타임스탬프 형식")
         private Long startDate;
         @Schema(description = "일정 종료일, unix 타임스탬프 형식")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantMaker.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantMaker.java
@@ -30,7 +30,6 @@ public class ParticipantMaker {
 
     public void makeScheduleOwner(Schedule schedule, Member member, Long categoryId, Long paletteId) {
         Category category;
-
         if (categoryId != null) {
             category = categoryService.readCategoryByMemberAndId(categoryId, member);
         } else

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantMaker.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantMaker.java
@@ -37,14 +37,14 @@ public class ParticipantMaker {
         Palette palette = paletteId != null ? paletteService.getPalette(paletteId) :  null;
 
         Participant participant = Participant.of(ParticipantRole.OWNER.getValue(), member, schedule,
-                ParticipantStatus.ACTIVE, category, palette);
+                ParticipantStatus.ACTIVE, category, palette, schedule.getTitle(), schedule.getImageUrl());
         participantService.createParticipant(participant);
     }
 
     public void makeMeetingScheduleParticipants(Schedule schedule, List<Member> members) {
         List<Participant> participants = members.stream()
                 .map(member -> Participant.of(ParticipantRole.NON_OWNER.getValue(), member, schedule,
-                        ParticipantStatus.INACTIVE, null, null))
+                        ParticipantStatus.INACTIVE, null, null, null, null))
                 .collect(Collectors.toList());
         participantService.createParticipants(participants);
     }
@@ -52,7 +52,7 @@ public class ParticipantMaker {
     public Participant makeGuestParticipant(Schedule schedule, Anonymous anonymous, Long paletteId) {
         Palette palette = paletteService.getPalette(paletteId);
         Participant participant = Participant.of(ParticipantRole.NON_OWNER.getValue(), anonymous, schedule,
-                ParticipantStatus.ACTIVE, null, palette);
+                ParticipantStatus.ACTIVE, null, palette, schedule.getTitle(), schedule.getImageUrl());
         Participant savedParticipant = participantService.createParticipant(participant);
         schedule.addActiveParticipant(anonymous.getNickname());
         return savedParticipant;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantMaker.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantMaker.java
@@ -30,14 +30,20 @@ public class ParticipantMaker {
 
     public void makeScheduleOwner(Schedule schedule, Member member, Long categoryId, Long paletteId) {
         Category category;
+
         if (categoryId != null) {
             category = categoryService.readCategoryByMemberAndId(categoryId, member);
         } else
             category = categoryService.readMeetingCategoryByMember(member);
         Palette palette = paletteId != null ? paletteService.getPalette(paletteId) :  null;
 
-        Participant participant = Participant.of(ParticipantRole.OWNER.getValue(), member, schedule,
-                ParticipantStatus.ACTIVE, category, palette, schedule.getTitle(), schedule.getImageUrl());
+        Participant participant;
+        if(schedule.getIsMeetingSchedule()){
+            participant = Participant.of(ParticipantRole.OWNER.getValue(), member, schedule,
+                    ParticipantStatus.ACTIVE, category, palette, schedule.getTitle(), schedule.getImageUrl());
+        } else participant = Participant.of(ParticipantRole.OWNER.getValue(), member, schedule,
+                ParticipantStatus.ACTIVE, category, palette, null, null);
+
         participantService.createParticipant(participant);
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantManageService.java
@@ -9,11 +9,8 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import com.namo.spring.application.external.api.guest.service.GuestManageService;
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
-import com.namo.spring.application.external.api.user.service.TagGenerator;
 import com.namo.spring.core.common.code.status.ErrorStatus;
-import com.namo.spring.db.mysql.domains.category.type.ColorChip;
 import com.namo.spring.db.mysql.domains.record.exception.DiaryException;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleMaker.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleMaker.java
@@ -1,21 +1,16 @@
 package com.namo.spring.application.external.api.schedule.service;
 
-import static com.namo.spring.application.external.api.schedule.converter.ScheduleConverter.*;
-
-import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
 import com.namo.spring.application.external.api.schedule.dto.PersonalScheduleRequest;
-import com.namo.spring.core.infra.common.aws.s3.FileUtils;
-import com.namo.spring.core.infra.common.constant.FilePath;
 import com.namo.spring.core.infra.common.properties.ImageUrlProperties;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.service.ScheduleService;
 import com.namo.spring.db.mysql.domains.schedule.type.Period;
 import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.namo.spring.application.external.api.schedule.converter.ScheduleConverter.toSchedule;
 
 @Component
 @RequiredArgsConstructor
@@ -25,7 +20,6 @@ public class ScheduleMaker {
 
     private final ScheduleService scheduleService;
     private final ImageUrlProperties imageUrlProperties;
-    private final FileUtils fileUtils;
 
     public Schedule createPersonalSchedule(PersonalScheduleRequest.PostPersonalScheduleDto dto, Period period,
             String nickname) {
@@ -34,14 +28,9 @@ public class ScheduleMaker {
         return scheduleService.createSchedule(schedule);
     }
 
-    public Schedule createMeetingSchedule(MeetingScheduleRequest.PostMeetingScheduleDto dto, Period period,
-            MultipartFile image) {
-        String url = imageUrlProperties.getMeeting();
-        if (image != null && !image.isEmpty()) {
-            url = fileUtils.uploadImage(image, FilePath.MEETING_PROFILE_IMG);
-        }
-
-        Schedule schedule = toSchedule(dto.getTitle(), period, dto.getLocation(), MEETING_SCHEDULE_TYPE, url, 0, "");
+    public Schedule createMeetingSchedule(MeetingScheduleRequest.PostMeetingScheduleDto dto, Period period) {
+        String imageUrl = dto.getImageUrl() != null ? dto.getImageUrl() : imageUrlProperties.getMeeting();
+        Schedule schedule = toSchedule(dto.getTitle(), period, dto.getLocation(), MEETING_SCHEDULE_TYPE, imageUrl, 0, "");
         return scheduleService.createSchedule(schedule);
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
@@ -6,6 +6,7 @@ import static com.namo.spring.application.external.global.utils.SchedulePeriodVa
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery;
 import org.springframework.stereotype.Service;
 
 import com.namo.spring.application.external.api.schedule.converter.LocationConverter;
@@ -79,12 +80,8 @@ public class ScheduleManageService {
         return schedule;
     }
 
-    public List<Schedule> getMeetingScheduleSummaries(Long memberId) {
-        List<Long> scheduleIds = participantService.readScheduleParticipantSummaryByScheduleIds(memberId).stream()
-                .map(Participant::getSchedule)
-                .map(Schedule::getId)
-                .collect(Collectors.toList());
-        return scheduleService.readSchedulesById(scheduleIds);
+    public List<ScheduleSummaryQuery> getMeetingScheduleSummaries(Long memberId) {
+        return participantService.readScheduleParticipantSummaryByScheduleIds(memberId);
     }
 
     public List<Participant> getMyMonthlySchedules(Long memberId, Period period) {

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.namo.spring.application.external.api.schedule.converter.LocationConverter;
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
@@ -70,13 +69,12 @@ public class ScheduleManageService {
         return schedule;
     }
 
-    public Schedule createMeetingSchedule(MeetingScheduleRequest.PostMeetingScheduleDto dto, Member owner,
-            MultipartFile image) {
+    public Schedule createMeetingSchedule(MeetingScheduleRequest.PostMeetingScheduleDto dto, Member owner) {
         validateParticipantCount(dto.getParticipants().size());
         List<Member> participants = participantManageService.getFriendshipValidatedParticipants(owner.getId(),
                 dto.getParticipants());
         Period period = getValidatedPeriod(dto.getPeriod().getStartDate(), dto.getPeriod().getEndDate());
-        Schedule schedule = scheduleMaker.createMeetingSchedule(dto, period, image);
+        Schedule schedule = scheduleMaker.createMeetingSchedule(dto, period);
         participantManageService.createMeetingScheduleParticipants(owner, schedule, participants);
         return schedule;
     }
@@ -131,7 +129,7 @@ public class ScheduleManageService {
 
     public List<ScheduleParticipantQuery> getMonthlyMeetingParticipantSchedules(Schedule schedule, Period period,
             Long memberId, Long anonymousId) {
-        checkParticipantExists(schedule, memberId, null);
+        checkUserIsParticipant(schedule, memberId, null);
         List<Participant> participants = participantService.readParticipantsByScheduleIdAndStatusAndType(
                 schedule.getId(), ScheduleType.MEETING, ParticipantStatus.ACTIVE);
         List<Long> members = participants.stream()
@@ -165,7 +163,7 @@ public class ScheduleManageService {
         return participant.getMemberId().equals(memberId) || participant.getIsShared();
     }
 
-    private void checkParticipantExists(Schedule schedule, Long memberId, Long anonymousId) {
+    private void checkUserIsParticipant(Schedule schedule, Long memberId, Long anonymousId) {
         boolean isParticipant;
         if (memberId != null)
             isParticipant = participantService.existsByScheduleIdAndMemberId(schedule.getId(), memberId);
@@ -177,7 +175,7 @@ public class ScheduleManageService {
     }
 
     public List<Participant> getMeetingScheduleParticipants(Schedule schedule, Long memberId, Long anonymousId) {
-        checkParticipantExists(schedule, memberId, anonymousId);
+        checkUserIsParticipant(schedule, memberId, anonymousId);
         return participantService.readParticipantsByScheduleIdAndStatusAndType(schedule.getId(), ScheduleType.MEETING,
                 null);
     }
@@ -185,13 +183,13 @@ public class ScheduleManageService {
     public void updatePersonalSchedule(PersonalScheduleRequest.PatchPersonalScheduleDto dto, Schedule schedule,
             Long memberId) {
         validateScheduleOwner(schedule, memberId);
-        updateScheduleContent(dto.getTitle(), dto.getLocation(), dto.getPeriod(), schedule);
+        updateScheduleContent(dto.getTitle(), dto.getLocation(), dto.getPeriod(), null, schedule);
     }
 
-    public void updateMeetingSchedule(MeetingScheduleRequest.PatchMeetingScheduleDto dto, Schedule schedule,
-            Long memberId) {
+    public void updateMeetingScheduleForOwner(MeetingScheduleRequest.PatchMeetingScheduleDto dto, Schedule schedule,
+                                              Long memberId) {
         validateScheduleOwner(schedule, memberId);
-        updateScheduleContent(dto.getTitle(), dto.getLocation(), dto.getPeriod(), schedule);
+        updateScheduleContent(dto.getTitle(), dto.getLocation(), dto.getPeriod(), dto.getImageUrl(), schedule);
         // 기존의 인원과, 초대될 & 삭제될 member  검증
         if (!dto.getParticipantsToAdd().isEmpty() || !dto.getParticipantsToRemove().isEmpty()) {
             List<Long> participantIds = getScheduleParticipantIds(schedule.getId());
@@ -200,6 +198,12 @@ public class ScheduleManageService {
             validateExistingAndNewParticipantIds(participantIds, dto.getParticipantsToAdd());
             participantManageService.updateMeetingScheduleParticipants(memberId, schedule, dto);
         }
+    }
+
+    public void updateMeetingScheduleForNonOwner(MeetingScheduleRequest.PatchMeetingScheduleProfileDto dto, Schedule schedule,
+                                                 Long memberId){
+        Participant participant = participantManageService.getScheduleParticipant(memberId, schedule.getId());
+        participant.updateCustomScheduleInfo(dto.getTitle(), dto.getImageUrl());
     }
 
     /**
@@ -220,10 +224,10 @@ public class ScheduleManageService {
     }
 
     private void updateScheduleContent(String title, MeetingScheduleRequest.LocationDto locationDto,
-            MeetingScheduleRequest.PeriodDto periodDto, Schedule schedule) {
+            MeetingScheduleRequest.PeriodDto periodDto, String imageUrl, Schedule schedule) {
         Period period = getValidatedPeriod(periodDto.getStartDate(), periodDto.getEndDate());
         Location location = locationDto != null ? LocationConverter.toLocation(locationDto) : null;
-        schedule.updateContent(title, period, location);
+        schedule.updateContent(title, period, location, imageUrl);
     }
 
     public void validateScheduleOwner(Schedule schedule, Long memberId) {

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
@@ -79,7 +79,7 @@ public class ScheduleManageService {
         return schedule;
     }
 
-    public List<Schedule> getMeetingScheduleItems(Long memberId) {
+    public List<Schedule> getMeetingScheduleSummaries(Long memberId) {
         List<Long> scheduleIds = participantService.readScheduleParticipantSummaryByScheduleIds(memberId).stream()
                 .map(Participant::getSchedule)
                 .map(Schedule::getId)

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
@@ -186,8 +186,11 @@ public class ScheduleManageService {
         updateScheduleContent(dto.getTitle(), dto.getLocation(), dto.getPeriod(), null, schedule);
     }
 
-    public void updateMeetingScheduleForOwner(MeetingScheduleRequest.PatchMeetingScheduleDto dto, Schedule schedule,
-                                              Long memberId) {
+    /**
+     * 모임 일정의 정보를 수정합니다.
+     */
+    public void updateMeetingSchedule(MeetingScheduleRequest.PatchMeetingScheduleDto dto, Schedule schedule,
+                                      Long memberId) {
         validateScheduleOwner(schedule, memberId);
         updateScheduleContent(dto.getTitle(), dto.getLocation(), dto.getPeriod(), dto.getImageUrl(), schedule);
         // 기존의 인원과, 초대될 & 삭제될 member  검증
@@ -200,8 +203,11 @@ public class ScheduleManageService {
         }
     }
 
-    public void updateMeetingScheduleForNonOwner(MeetingScheduleRequest.PatchMeetingScheduleProfileDto dto, Schedule schedule,
-                                                 Long memberId){
+    /**
+     * 모임 일정의 제목, 이미지를 커스텀 합니다.
+     */
+    public void updateMeetingScheduleProfile(MeetingScheduleRequest.PatchMeetingScheduleProfileDto dto, Schedule schedule,
+                                             Long memberId){
         Participant participant = participantManageService.getScheduleParticipant(memberId, schedule.getId());
         participant.updateCustomScheduleInfo(dto.getTitle(), dto.getImageUrl());
     }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
@@ -9,7 +9,6 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.namo.spring.application.external.api.guest.service.GuestManageService;
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
@@ -35,11 +34,10 @@ public class MeetingScheduleUsecase {
     private final GuestManageService guestManageService;
 
     @Transactional
-    public Long createMeetingSchedule(MeetingScheduleRequest.PostMeetingScheduleDto dto, MultipartFile image,
-            SecurityUserDetails memberInfo) {
+    public Long createMeetingSchedule(MeetingScheduleRequest.PostMeetingScheduleDto dto, SecurityUserDetails memberInfo) {
         validateUniqueParticipantIds(memberInfo.getUserId(), dto.getParticipants());
         Member owner = memberManageService.getMember(memberInfo.getUserId());
-        Schedule schedule = scheduleManageService.createMeetingSchedule(dto, owner, image);
+        Schedule schedule = scheduleManageService.createMeetingSchedule(dto, owner);
         return schedule.getId();
     }
 
@@ -81,10 +79,17 @@ public class MeetingScheduleUsecase {
 
     @Transactional
     public void updateMeetingSchedule(MeetingScheduleRequest.PatchMeetingScheduleDto dto, Long scheduleId,
-            SecurityUserDetails memberInfo) {
+                                      SecurityUserDetails memberInfo) {
         validateUniqueParticipantIds(memberInfo.getUserId(), dto);
         Schedule schedule = scheduleManageService.getMeetingSchedule(scheduleId);
         scheduleManageService.updateMeetingSchedule(dto, schedule, memberInfo.getUserId());
+    }
+
+    @Transactional
+    public void updateMeetingScheduleProfile(MeetingScheduleRequest.PatchMeetingScheduleProfileDto dto, Long scheduleId,
+                                             SecurityUserDetails memberInfo){
+        Schedule schedule = scheduleManageService.getMeetingSchedule(scheduleId);
+        scheduleManageService.updateMeetingScheduleProfile(dto, schedule, memberInfo.getUserId());
     }
 
     @Transactional

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
@@ -93,7 +93,7 @@ public class MeetingScheduleUsecase {
     }
 
     @Transactional
-    public String getGuestInviteCode(Long scheduleId, SecurityUserDetails memberInfo) {
+    public String getGuestInvitationUrl(Long scheduleId, SecurityUserDetails memberInfo) {
         Schedule schedule = scheduleManageService.getMeetingSchedule(scheduleId);
         scheduleManageService.validateScheduleOwner(schedule, memberInfo.getUserId());
         validateParticipantCount(scheduleManageService.getScheduleParticipantIds(schedule.getId()).size());

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
@@ -97,6 +97,6 @@ public class MeetingScheduleUsecase {
         Schedule schedule = scheduleManageService.getMeetingSchedule(scheduleId);
         scheduleManageService.validateScheduleOwner(schedule, memberInfo.getUserId());
         validateParticipantCount(scheduleManageService.getScheduleParticipantIds(schedule.getId()).size());
-        return guestManageService.generateInviteCode(scheduleId);
+        return guestManageService.generateInvitationUrl(scheduleId);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
@@ -43,7 +43,7 @@ public class MeetingScheduleUsecase {
 
     @Transactional(readOnly = true)
     public List<MeetingScheduleResponse.GetMeetingScheduleSummaryDto> getMeetingSchedules(SecurityUserDetails member) {
-        return toGetMeetingScheduleSummaryDtos(scheduleManageService.getMeetingScheduleItems(member.getUserId()));
+        return toGetMeetingScheduleSummaryDtos(scheduleManageService.getMeetingScheduleSummaries(member.getUserId()));
     }
 
     @Transactional(readOnly = true)
@@ -54,7 +54,7 @@ public class MeetingScheduleUsecase {
 
         List<ScheduleParticipantQuery> participantsWithSchedule = scheduleManageService.getMonthlyMembersSchedules(
                 memberIds, getExtendedPeriod(year, month), memberInfo.getUserId());
-        return toGetMonthlyParticipantScheduleDtos(participantsWithSchedule, memberIds, memberInfo.getUserId());
+        return toGetMonthlyMembersScheduleDtos(participantsWithSchedule,memberInfo.getUserId());
     }
 
     @Transactional(readOnly = true)
@@ -65,7 +65,7 @@ public class MeetingScheduleUsecase {
         Schedule schedule = scheduleManageService.getMeetingSchedule(scheduleId);
         List<ScheduleParticipantQuery> participantsWithSchedule = scheduleManageService.getMonthlyMeetingParticipantSchedules(
                 schedule, getExtendedPeriod(year, month), memberInfo.getUserId(), null);
-        return toGetMonthlyMeetingParticipantScheduleDtos(participantsWithSchedule, schedule);
+        return toGetMonthlyMeetingParticipantScheduleDtos(participantsWithSchedule, schedule, memberInfo.getUserId());
     }
 
     @Transactional(readOnly = true)
@@ -74,7 +74,7 @@ public class MeetingScheduleUsecase {
         Schedule schedule = scheduleManageService.getMeetingSchedule(scheduleId);
         List<Participant> participants = scheduleManageService.getMeetingScheduleParticipants(schedule,
                 memberInfo.getUserId(), null);
-        return toGetMeetingScheduleDto(schedule, participants);
+        return toGetMeetingScheduleDto(schedule, participants, memberInfo.getUserId());
     }
 
     @Transactional

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/config/properties/WebUrlConfig.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/config/properties/WebUrlConfig.java
@@ -1,0 +1,12 @@
+package com.namo.spring.application.external.global.config.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "url")
+public class WebUrlConfig {
+    private final String invitation;
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/MeetingParticipantValidationUtils.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/MeetingParticipantValidationUtils.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.db.mysql.domains.schedule.exception.ParticipantException;
-import com.namo.spring.db.mysql.domains.schedule.exception.ScheduleException;
 
 import lombok.RequiredArgsConstructor;
 

--- a/application/external-api-v2/src/main/resources/application.yml
+++ b/application/external-api-v2/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
       - redis.yml
       - mysql.yml
       - logging.yml
+      - web.yml
   web.resources.add-mappings: false
 
 server:

--- a/application/external-api-v2/src/main/resources/web.yml
+++ b/application/external-api-v2/src/main/resources/web.yml
@@ -1,0 +1,2 @@
+url:
+  invitation: ${WEB_INVITATION_URL:http://localhost:3000/}

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/dto/ScheduleParticipantQuery.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/dto/ScheduleParticipantQuery.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@Builder
 @AllArgsConstructor
 public class ScheduleParticipantQuery {
     private Long participantId;

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/dto/ScheduleParticipantQuery.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/dto/ScheduleParticipantQuery.java
@@ -17,5 +17,7 @@ public class ScheduleParticipantQuery {
     private Long memberId;
     private String nickname;
     private Schedule schedule;
+    private String customTitle;
+    private String customImage;
     private Boolean isShared;
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/dto/ScheduleSummaryQuery.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/dto/ScheduleSummaryQuery.java
@@ -1,0 +1,19 @@
+package com.namo.spring.db.mysql.domains.schedule.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleSummaryQuery {
+    private Long meetingScheduleId;
+    private String title;
+    private LocalDateTime startDate;
+    private String imageUrl;
+    private Integer participantCount;
+    private String participantNicknames;
+}

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
@@ -30,6 +30,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Getter
 @Entity
@@ -69,6 +71,13 @@ public class Participant extends BaseTimeEntity {
     @JoinColumn(name = "palette_id", nullable = true)
     private Palette palette;
 
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(length = 50)
+    private String customTitle;
+
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    private String customImage;
+
     private boolean hasDiary;
 
     @OneToOne(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
@@ -84,6 +93,8 @@ public class Participant extends BaseTimeEntity {
         this.status = Objects.requireNonNull(status, "status는 null일 수 없습니다.");
         this.category = category;
         this.palette = palette;
+        this.customTitle = schedule.getTitle();
+        this.customImage = schedule.getImageUrl();
         this.hasDiary = false;
     }
 
@@ -112,6 +123,11 @@ public class Participant extends BaseTimeEntity {
         this.status = ParticipantStatus.ACTIVE;
         this.category = category;
         this.palette = palette;
+    }
+
+    public void updateCustomScheduleInfo(String title, String imageUrl) {
+        this.customTitle = title;
+        this.customImage = imageUrl;
     }
 
     public void inactiveStatus() {

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
@@ -93,8 +93,6 @@ public class Participant extends BaseTimeEntity {
         this.status = Objects.requireNonNull(status, "status는 null일 수 없습니다.");
         this.category = category;
         this.palette = palette;
-        this.customTitle = schedule.getTitle();
-        this.customImage = schedule.getImageUrl();
         this.hasDiary = false;
     }
 
@@ -123,6 +121,8 @@ public class Participant extends BaseTimeEntity {
         this.status = ParticipantStatus.ACTIVE;
         this.category = category;
         this.palette = palette;
+        this.customTitle = schedule.getTitle();
+        this.customImage = schedule.getImageUrl();
     }
 
     public void updateCustomScheduleInfo(String title, String imageUrl) {

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
@@ -85,7 +85,7 @@ public class Participant extends BaseTimeEntity {
 
     @Builder
     public Participant(int isOwner, User user, Schedule schedule, ParticipantStatus status, Category category,
-            Palette palette) {
+            Palette palette, String customTitle, String customImage) {
         this.isOwner = Objects.requireNonNull(isOwner, "isOwner은 null일 수 없습니다.");
         this.member = user instanceof Member ? (Member)user : null;
         this.anonymous = user instanceof Anonymous ? (Anonymous)user : null;
@@ -94,10 +94,12 @@ public class Participant extends BaseTimeEntity {
         this.category = category;
         this.palette = palette;
         this.hasDiary = false;
+        this.customTitle = customTitle;
+        this.customImage =customImage;
     }
 
     public static Participant of(int isOwner, User user, Schedule schedule, ParticipantStatus status, Category category,
-            Palette palette) {
+            Palette palette, String customTitle, String customImage) {
         return Participant.builder()
                 .isOwner(isOwner)
                 .user(user)
@@ -105,6 +107,8 @@ public class Participant extends BaseTimeEntity {
                 .status(status)
                 .category(category)
                 .palette(palette)
+                .customTitle(customTitle)
+                .customImage(customImage)
                 .build();
     }
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Participant.java
@@ -146,4 +146,12 @@ public class Participant extends BaseTimeEntity {
         this.hasDiary = false;
     }
 
+    public String getScheduleTitle(){
+        return schedule.getIsMeetingSchedule() ? this.getCustomTitle() : schedule.getTitle();
+    }
+
+    public String getScheduleImage(){
+        return schedule.getIsMeetingSchedule() ? this.getCustomImage() : schedule.getImageUrl();
+    }
+
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -160,5 +161,9 @@ public class Schedule extends BaseTimeEntity {
     private void updateParticipants(List<String> updatedNicknames) {
         this.participantNicknames = String.join(", ", updatedNicknames);
         this.participantCount = updatedNicknames.size();
+    }
+
+    public boolean getIsMeetingSchedule() {
+        return this.scheduleType == ScheduleType.MEETING.getValue();
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
@@ -60,8 +60,6 @@ public class Schedule extends BaseTimeEntity {
 
     private String participantNicknames;
 
-    private String invitationUrl;
-
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Activity> activityList;
 
@@ -95,11 +93,14 @@ public class Schedule extends BaseTimeEntity {
                 .build();
     }
 
-    public void updateContent(String title, Period period, Location location) {
+    public void updateContent(String title, Period period, Location location, String imageUrl) {
         this.title = title;
         this.period = period;
         if (location != null) {
             this.location = location;
+        }
+        if (imageUrl != null) {
+            this.imageUrl = imageUrl;
         }
     }
 
@@ -159,9 +160,5 @@ public class Schedule extends BaseTimeEntity {
     private void updateParticipants(List<String> updatedNicknames) {
         this.participantNicknames = String.join(", ", updatedNicknames);
         this.participantCount = updatedNicknames.size();
-    }
-
-    public void updateInvitationUrl(String invitationUrl) {
-        this.invitationUrl = invitationUrl;
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,8 +18,11 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     List<Participant> findAllByScheduleId(Long scheduleId);
 
-    @Query("SELECT p FROM Participant p JOIN p.schedule s JOIN p.member m WHERE p.member.id = :memberId AND p.status = 'ACTIVE' AND s.scheduleType = :scheduleType")
-    List<Participant> findParticipantsByMemberAndScheduleType(Long memberId, int scheduleType);
+    @Query("SELECT new com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery(" +
+            "s.id, p.customTitle, s.period.startDate, p.customImage, s.participantCount, s.participantNicknames) " +
+            "FROM Participant p JOIN p.schedule s JOIN p.member m " +
+            "WHERE p.member.id = :memberId AND p.status = 'ACTIVE' AND s.scheduleType = :scheduleType")
+    List<ScheduleSummaryQuery> findScheduleSummaryByMemberAndScheduleType(Long memberId, int scheduleType);
 
     boolean existsByScheduleIdAndMemberId(Long scheduleId, Long memberId);
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -42,7 +42,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     List<Participant> findParticipantByIdAndScheduleId(List<Long> ids, Long scheduleId, ParticipantStatus status);
 
     @Query("SELECT DISTINCT new com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery(" +
-        "p.id, m.palette.id, m.id, m.nickname, s, p.category.isShared" +
+        "p.id, m.palette.id, m.id, m.nickname, s, p.customTitle, p.customImage, p.category.isShared" +
         ") FROM Participant p " +
         "JOIN p.schedule s " +
         "JOIN p.member m " +

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,8 +53,8 @@ public class ParticipantService {
     }
 
     @Transactional(readOnly = true)
-    public List<Participant> readScheduleParticipantSummaryByScheduleIds(Long memberId) {
-        return participantRepository.findParticipantsByMemberAndScheduleType(memberId, ScheduleType.MEETING.getValue());
+    public List<ScheduleSummaryQuery> readScheduleParticipantSummaryByScheduleIds(Long memberId) {
+        return participantRepository.findScheduleSummaryByMemberAndScheduleType(memberId, ScheduleType.MEETING.getValue());
     }
 
     @Transactional(readOnly = true)

--- a/storage/db-mysql-v2/src/main/resources/db/migration/dev/V1.0.6__Drop_invitation_url_column_from_schedule_table.sql
+++ b/storage/db-mysql-v2/src/main/resources/db/migration/dev/V1.0.6__Drop_invitation_url_column_from_schedule_table.sql
@@ -1,0 +1,5 @@
+-- V1.0.6__Drop_invitation_url_column_from_schedule_table
+
+-- invitation_url 삭제
+ALTER TABLE schedule
+    DROP COLUMN invitation_url;

--- a/storage/db-mysql-v2/src/main/resources/db/migration/dev/V1.0.7__Add_columns_to_participant_table.sql
+++ b/storage/db-mysql-v2/src/main/resources/db/migration/dev/V1.0.7__Add_columns_to_participant_table.sql
@@ -1,0 +1,18 @@
+-- V1.0.7__Add_columns_to_participant_table
+
+-- custom_title 컬럼 추가
+ALTER TABLE participant
+    ADD COLUMN custom_title VARCHAR(50) NULL,
+    ADD COLUMN custom_image VARCHAR(255) NULL;
+
+-- 기존 레코드에 대해 기본값 설정
+UPDATE participant p
+    LEFT JOIN schedule s ON p.schedule_id = s.id
+SET p.custom_title = s.title
+WHERE s.schedule_type = 1 AND p.custom_title IS NULL;
+
+UPDATE participant p
+    LEFT JOIN schedule s ON p.schedule_id = s.id
+SET p.custom_image = s.image_url
+WHERE s.schedule_type = 1 AND p.custom_image IS NULL;
+

--- a/storage/db-mysql-v2/src/main/resources/mysql.yml
+++ b/storage/db-mysql-v2/src/main/resources/mysql.yml
@@ -21,16 +21,15 @@ spring.config.activate.on-profile: local
 
 spring:
   flyway:
-    enabled: false
-    baseline-version: 1.0.0
+    enabled: true
     baseline-on-migrate: true
-    locations: classpath:db/migration
+    locations: classpath:db/migration/dev
   jpa:
     database: MySQL
     open-in-view: false
     generate-ddl: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 모임 일정에 대해 방장이 아닌 참여자는 모임 제목, 이미지를 수정이 가능해짐

- participant -> custom_title, custom_image 컬럼 추가
  - 일정의 제목, 이미지가 조회되는 경우에 대해 
 모임 일정 -> participant의 custom 정보 조회, 개인 일정 -> schedule의 정보 조회되도록 로직 수정

- 모임 이미지 수정이 가능해지면서 이미지 업로드 방식 presigned url 방식으로 변경

- 모임 제목&이미지 수정 API 구현

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #297 
