### PR TITLE
[Feature/325] 친구관련 기능 구현 (+ 유저 조회로직 구분)

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/usecase/CategoryUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/category/usecase/CategoryUseCase.java
@@ -32,7 +32,7 @@ public class CategoryUseCase {
 
     @Transactional
     public void createCategory(Long memberId, CategoryRequest.CategoryCreateDto request){
-        Member member = memberManageService.getMember(memberId);
+        Member member = memberManageService.getActiveMember(memberId);
         categoryManageService.createCategory(member, request);
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/service/GuestManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/service/GuestManageService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 
 import com.namo.spring.application.external.api.guest.dto.GuestParticipantRequest;
 import com.namo.spring.application.external.api.schedule.service.ParticipantMaker;
-import com.namo.spring.application.external.api.user.service.TagGenerator;
+import com.namo.spring.application.external.global.utils.TagGenerator;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.db.mysql.domains.category.entity.Palette;
 import com.namo.spring.db.mysql.domains.category.exception.PaletteException;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
@@ -36,7 +36,7 @@ public class MeetingScheduleUsecase {
     @Transactional
     public Long createMeetingSchedule(MeetingScheduleRequest.PostMeetingScheduleDto dto, SecurityUserDetails memberInfo) {
         validateUniqueParticipantIds(memberInfo.getUserId(), dto.getParticipants());
-        Member owner = memberManageService.getMember(memberInfo.getUserId());
+        Member owner = memberManageService.getActiveMember(memberInfo.getUserId());
         Schedule schedule = scheduleManageService.createMeetingSchedule(dto, owner);
         return schedule.getId();
     }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/PersonalScheduleUsecase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/PersonalScheduleUsecase.java
@@ -34,7 +34,7 @@ public class PersonalScheduleUsecase {
     @Transactional
     public Long createPersonalSchedule(PersonalScheduleRequest.PostPersonalScheduleDto dto,
             SecurityUserDetails memberInfo) throws JsonProcessingException {
-        Member member = memberManageService.getMember(memberInfo.getUserId());
+        Member member = memberManageService.getActiveMember(memberInfo.getUserId());
         Schedule schedule = scheduleManageService.createPersonalSchedule(dto, member);
         if (!dto.getReminderTrigger().isEmpty()) {
             notificationManageService.createScheduleReminderNotification(schedule, member, dto.getReminderTrigger());
@@ -62,7 +62,7 @@ public class PersonalScheduleUsecase {
     @Transactional(readOnly = true)
     public List<PersonalScheduleResponse.GetFriendMonthlyScheduleDto> getFriendMonthlySchedules(int year, int month,
             Long targetMemberId, SecurityUserDetails memberInfo) {
-        Member targetMember = memberManageService.getMember(targetMemberId);
+        Member targetMember = memberManageService.getActiveMember(targetMemberId);
         return toGetFriendMonthlyScheduleDtos(
                 scheduleManageService.getMemberMonthlySchedules(targetMember.getId(), memberInfo.getUserId(),
                         getExtendedPeriod(year, month)));

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/ScheduleUsecase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/ScheduleUsecase.java
@@ -31,7 +31,7 @@ public class ScheduleUsecase {
     @Transactional
     public void updateOrCreateScheduleReminder(ScheduleRequest.PutScheduleReminderDto dto, Long scheduleId,
             SecurityUserDetails memberInfo) {
-        Member member = memberManageService.getMember(memberInfo.getUserId());
+        Member member = memberManageService.getActiveMember(memberInfo.getUserId());
         notificationManageService.updateOrCreateScheduleReminderNotification(scheduleId, member,
                 dto.getReminderTrigger());
     }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/AuthController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/AuthController.java
@@ -33,7 +33,7 @@ public class AuthController{
 
     private final AuthFacade memberFacade;
 
-    @Operation(summary = "소셜 회원가입", description = "카카오,네이버 소셜 로그인을 통한 회원가입을 진행합니다.")
+    @Operation(summary = "애플 회원가입", description = "애플 소셜 로그인을 통한 회원가입을 진행합니다.")
     @PostMapping(value = "/signup/apple")
     @PreAuthorize("isAnonymous()")
     public ResponseDto<MemberResponse.SignUpDto> appleSignup(
@@ -43,7 +43,7 @@ public class AuthController{
         return ResponseDto.onSuccess(signupDto);
     }
 
-    @Operation(summary = "애플 회원가입", description = "애플 소셜 로그인을 통한 회원가입을 진행합니다.")
+    @Operation(summary = "소셜 회원가입", description = "카카오,네이버 소셜 로그인을 통한 회원가입을 진행합니다.")
     @PostMapping(value = "/signup/{socialType}")
     @PreAuthorize("isAnonymous()")
     public ResponseDto<MemberResponse.SignUpDto> socialSignup(

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -1,5 +1,7 @@
 package com.namo.spring.application.external.api.user.controller;
 
+import static com.namo.spring.core.common.code.status.ErrorStatus.*;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -7,9 +9,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.namo.spring.application.external.api.user.usecase.FriendUseCase;
+import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
 import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
 import com.namo.spring.core.common.response.ResponseDto;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -23,12 +27,18 @@ public class FriendController {
 
     private final FriendUseCase friendUseCase;
 
+    @Operation(summary = "친구를 요청합니다.", description = "친구 요청 API 입니다. 상대방이 수락을 해야 친구가 됩니다.")
+    @ApiErrorCodes(value = {
+            NOT_FOUND_USER_FAILURE,
+            AlREADY_FRIENDSHIP_MEMBER
+    })
     @PostMapping("/{memberId}")
     public ResponseDto<String> requestFriend(
             @AuthenticationPrincipal SecurityUserDetails member,
             @Parameter(description = "친구 요청할 상대방 사용자의 ID 입니다.", example = "3")
             @PathVariable Long memberId
     ) {
-        return null;
+        friendUseCase.requestFriendship(member.getUserId(), memberId);
+        return ResponseDto.onSuccess("친구 요청이 전송되었습니다.");
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -38,13 +38,13 @@ public class FriendController {
             NOT_FOUND_USER_FAILURE,
             AlREADY_FRIENDSHIP_MEMBER
     })
-    @PostMapping("/{memberId}")
+    @PostMapping("/{nickname-tag}")
     public ResponseDto<String> requestFriend(
             @AuthenticationPrincipal SecurityUserDetails member,
-            @Parameter(description = "친구 요청할 상대방 사용자의 ID 입니다.", example = "3")
-            @PathVariable Long memberId
+            @Parameter(description = "친구 요청할 상대방 사용자의 닉네임#태그 입니다.", example = "캐슬#2342")
+            @PathVariable String nickname
     ) {
-        friendUseCase.requestFriendship(member.getUserId(), memberId);
+        friendUseCase.requestFriendship(member.getUserId(), nickname);
         return ResponseDto.onSuccess("친구 요청이 전송되었습니다.");
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.namo.spring.application.external.api.user.dto.FriendshipResponse;
@@ -59,12 +60,17 @@ public class FriendController {
     }
 
     @Operation(summary = "친구 요청 수락", description = "수신한 친구 요청을 수락합니다.")
+    @ApiErrorCodes(value = {
+            NOT_FOUND_FRIENDSHIP_REQUEST,
+            NOT_MY_FRIENDSHIP_REQUEST
+    })
     @PatchMapping("/requests/{friendshipId}/accept")
     public ResponseDto<String> acceptFriendRequest(
             @AuthenticationPrincipal SecurityUserDetails member,
-            @Parameter(description = "수락할 친구요청의 ID (memberId가 아닙니다)", example = "10")
+            @Parameter(description = "수락할 친구 요청 정보 ID (memberId가 아닙니다)", example = "4")
             @PathVariable Long friendshipId
     ){
+        friendUseCase.acceptRequest(member.getUserId(), friendshipId);
         return ResponseDto.onSuccess("친구 요청을 수락했습니다.");
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -33,7 +33,8 @@ public class FriendController {
 
     private final FriendUseCase friendUseCase;
 
-    @Operation(summary = "친구를 요청합니다.", description = "친구 요청 API 입니다. 상대방이 수락을 해야 친구가 됩니다.")
+    @Operation(summary = "친구를 요청합니다.", description = "친구 요청 API 입니다. 상대방이 수락을 해야 친구가 됩니다."
+            + "만약 상대방이 친구 요청을 보낸 상태이면 요청할 수 없습니다.")
     @ApiErrorCodes(value = {
             NOT_FOUND_USER_FAILURE,
             AlREADY_FRIENDSHIP_MEMBER

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -50,10 +50,12 @@ public class FriendController {
     @Operation(summary = "나에게 온 친구 요청 목록을 조회합니다.", description = "친구 요청 목록 조회 API 입니다. 수락 또는 거절한 친구 요청은 표시되지 않습니다.")
     @GetMapping("/requests")
     public ResponseDto<List<FriendshipResponse.FriendRequestDto>> getFriendRequestList(
-            @AuthenticationPrincipal SecurityUserDetails member
+            @AuthenticationPrincipal SecurityUserDetails member,
+            @Parameter(description = "1 부터 시작하는 페이지 번호입니다 (기본값 1)", example = "1")
+            @RequestParam(value = "page", defaultValue = "1") int page
     ){
         return ResponseDto.onSuccess(friendUseCase
-                .getFriendshipRequest(member.getUserId()));
+                .getFriendshipRequest(member.getUserId(), page));
     }
 
     @Operation(summary = "친구 요청 수락", description = "수신한 친구 요청을 수락합니다.")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,5 +54,15 @@ public class FriendController {
     ){
         return ResponseDto.onSuccess(friendUseCase
                 .getFriendshipRequest(member.getUserId()));
+    }
+
+    @Operation(summary = "친구 요청 수락", description = "수신한 친구 요청을 수락합니다.")
+    @PatchMapping("/requests/{friendshipId}/accept")
+    public ResponseDto<String> acceptFriendRequest(
+            @AuthenticationPrincipal SecurityUserDetails member,
+            @Parameter(description = "수락할 친구요청의 ID (memberId가 아닙니다)", example = "10")
+            @PathVariable Long friendshipId
+    ){
+        return ResponseDto.onSuccess("친구 요청을 수락했습니다.");
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -42,9 +42,9 @@ public class FriendController {
     public ResponseDto<String> requestFriend(
             @AuthenticationPrincipal SecurityUserDetails member,
             @Parameter(description = "친구 요청할 상대방 사용자의 닉네임#태그 입니다.", example = "캐슬#2342")
-            @PathVariable String nickname
+            @PathVariable(name = "nickname-tag") String nicknameTag
     ) {
-        friendUseCase.requestFriendship(member.getUserId(), nickname);
+        friendUseCase.requestFriendship(member.getUserId(), nicknameTag);
         return ResponseDto.onSuccess("친구 요청이 전송되었습니다.");
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -1,0 +1,34 @@
+package com.namo.spring.application.external.api.user.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.namo.spring.application.external.api.user.usecase.FriendUseCase;
+import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
+import com.namo.spring.core.common.response.ResponseDto;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "친구", description = "친구 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/friends")
+public class FriendController {
+
+    private final FriendUseCase friendUseCase;
+
+    @PostMapping("/{memberId}")
+    public ResponseDto<String> requestFriend(
+            @AuthenticationPrincipal SecurityUserDetails member,
+            @Parameter(description = "친구 요청할 상대방 사용자의 ID 입니다.", example = "3")
+            @PathVariable Long memberId
+    ) {
+        return null;
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -74,7 +74,7 @@ public class FriendController {
         return ResponseDto.onSuccess("친구 요청을 수락했습니다.");
     }
 
-    @PatchMapping("/{friendshipId}/reject")
+    @PatchMapping("/requests/{friendshipId}/reject")
     @ApiErrorCodes(value = {
             NOT_FOUND_FRIENDSHIP_REQUEST,
             NOT_MY_FRIENDSHIP_REQUEST

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -2,12 +2,16 @@ package com.namo.spring.application.external.api.user.controller;
 
 import static com.namo.spring.core.common.code.status.ErrorStatus.*;
 
+import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.namo.spring.application.external.api.user.dto.FriendshipResponse;
 import com.namo.spring.application.external.api.user.usecase.FriendUseCase;
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
 import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
@@ -40,5 +44,12 @@ public class FriendController {
     ) {
         friendUseCase.requestFriendship(member.getUserId(), memberId);
         return ResponseDto.onSuccess("친구 요청이 전송되었습니다.");
+    }
+
+    @GetMapping("")
+    public ResponseDto<List<FriendshipResponse.FriendRequestDto>> getFriendRequestList(
+            @AuthenticationPrincipal SecurityUserDetails member
+    ){
+        return ResponseDto.onSuccess(null);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -75,11 +75,17 @@ public class FriendController {
     }
 
     @PatchMapping("/{friendshipId}/reject")
-    @Operation(summary = "친구 요청을 거절합니다.", description = "친구 요청을 거절하는 API 입니다.")
+    @ApiErrorCodes(value = {
+            NOT_FOUND_FRIENDSHIP_REQUEST,
+            NOT_MY_FRIENDSHIP_REQUEST
+    })
+    @Operation(summary = "친구 요청을 거절합니다.", description = "수신한 친구 요청을 거절하는 API 입니다.")
     public ResponseDto<String> rejectFriendRequest(
             @AuthenticationPrincipal SecurityUserDetails member,
-            @Parameter(description = "친구 요청 ID입니다.", example = "3") @PathVariable Long friendshipId
+            @Parameter(description = "거절할 친구 요청 정보 ID (memberId가 아닙니다)", example = "3")
+            @PathVariable Long friendshipId
     ) {
+        friendUseCase.rejectFriendRequest(member.getUserId(), friendshipId);
         return ResponseDto.onSuccess("친구 요청을 거절했습니다.");
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -73,4 +73,14 @@ public class FriendController {
         friendUseCase.acceptRequest(member.getUserId(), friendshipId);
         return ResponseDto.onSuccess("친구 요청을 수락했습니다.");
     }
+
+    @PatchMapping("/{friendshipId}/reject")
+    @Operation(summary = "친구 요청을 거절합니다.", description = "친구 요청을 거절하는 API 입니다.")
+    public ResponseDto<String> rejectFriendRequest(
+            @AuthenticationPrincipal SecurityUserDetails member,
+            @Parameter(description = "친구 요청 ID입니다.", example = "3") @PathVariable Long friendshipId
+    ) {
+        return ResponseDto.onSuccess("친구 요청을 거절했습니다.");
+    }
+
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -46,10 +46,12 @@ public class FriendController {
         return ResponseDto.onSuccess("친구 요청이 전송되었습니다.");
     }
 
-    @GetMapping("")
+    @Operation(summary = "나에게 온 친구 요청 목록을 조회합니다.", description = "친구 요청 목록 조회 API 입니다. 수락 또는 거절한 친구 요청은 표시되지 않습니다.")
+    @GetMapping("/requests")
     public ResponseDto<List<FriendshipResponse.FriendRequestDto>> getFriendRequestList(
             @AuthenticationPrincipal SecurityUserDetails member
     ){
-        return ResponseDto.onSuccess(null);
+        return ResponseDto.onSuccess(friendUseCase
+                .getFriendshipRequest(member.getUserId()));
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendShipConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendShipConverter.java
@@ -19,6 +19,7 @@ public class FriendShipConverter {
         Member friend = friendship.getFriend();
         String birthday = friend.isBirthdayVisible() ? friend.getBirthday() : BIRTHDAY_HIDDEN;
         return FriendshipResponse.FriendRequestDto.builder()
+                .friendRequestId(friendship.getId())
                 .memberId(friend.getId())
                 .profileImage(friend.getProfileImage())
                 .nickname(friend.getNickname())

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendShipConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendShipConverter.java
@@ -1,5 +1,6 @@
 package com.namo.spring.application.external.api.user.converter;
 
+import com.namo.spring.application.external.api.user.dto.FriendshipResponse;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 
@@ -9,6 +10,15 @@ public class FriendShipConverter {
         return Friendship.builder()
                 .member(request)
                 .friend(target)
+                .build();
+    }
+
+    public static FriendshipResponse.FriendRequestDto toFriendRequestDto(Friendship friendship){
+        return FriendshipResponse.FriendRequestDto.builder()
+                .profileImage(friendship.getFriend().getProfileImage())
+                .nickname(friendship.getFriend().getNickname())
+                .tag(friendship.getFriend().getTag())
+                .bio(friendship.getFriend().getBio())
                 .build();
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendShipConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendShipConverter.java
@@ -1,0 +1,14 @@
+package com.namo.spring.application.external.api.user.converter;
+
+import com.namo.spring.db.mysql.domains.user.entity.Friendship;
+import com.namo.spring.db.mysql.domains.user.entity.Member;
+
+public class FriendShipConverter {
+
+    public static Friendship toFriendShip(Member request, Member target){
+        return Friendship.builder()
+                .member(request)
+                .friend(target)
+                .build();
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendShipConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendShipConverter.java
@@ -6,6 +6,8 @@ import com.namo.spring.db.mysql.domains.user.entity.Member;
 
 public class FriendShipConverter {
 
+    private static final String BIRTHDAY_HIDDEN = "비공개";
+
     public static Friendship toFriendShip(Member request, Member target){
         return Friendship.builder()
                 .member(request)
@@ -14,11 +16,16 @@ public class FriendShipConverter {
     }
 
     public static FriendshipResponse.FriendRequestDto toFriendRequestDto(Friendship friendship){
+        Member friend = friendship.getFriend();
+        String birthday = friend.isBirthdayVisible() ? friend.getBirthday() : BIRTHDAY_HIDDEN;
         return FriendshipResponse.FriendRequestDto.builder()
-                .profileImage(friendship.getFriend().getProfileImage())
-                .nickname(friendship.getFriend().getNickname())
-                .tag(friendship.getFriend().getTag())
-                .bio(friendship.getFriend().getBio())
+                .memberId(friend.getId())
+                .profileImage(friend.getProfileImage())
+                .nickname(friend.getNickname())
+                .tag(friend.getTag())
+                .bio(friend.getBio())
+                .birthday(birthday)
+                .favoriteColorId(friend.getPalette().getId())
                 .build();
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
@@ -4,7 +4,7 @@ import com.namo.spring.application.external.api.user.dto.FriendshipResponse;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 
-public class FriendShipConverter {
+public class FriendshipConverter {
 
     private static final String BIRTHDAY_HIDDEN = "비공개";
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
@@ -16,17 +16,17 @@ public class FriendshipConverter {
     }
 
     public static FriendshipResponse.FriendRequestDto toFriendRequestDto(Friendship friendship){
-        Member friend = friendship.getFriend();
-        String birthday = friend.isBirthdayVisible() ? friend.getBirthday() : BIRTHDAY_HIDDEN;
+        Member requestMember = friendship.getMember();
+        String birthday = requestMember.isBirthdayVisible() ? requestMember.getBirthday() : BIRTHDAY_HIDDEN;
         return FriendshipResponse.FriendRequestDto.builder()
                 .friendRequestId(friendship.getId())
-                .memberId(friend.getId())
-                .profileImage(friend.getProfileImage())
-                .nickname(friend.getNickname())
-                .tag(friend.getTag())
-                .bio(friend.getBio())
+                .memberId(requestMember.getId())
+                .profileImage(requestMember.getProfileImage())
+                .nickname(requestMember.getNickname())
+                .tag(requestMember.getTag())
+                .bio(requestMember.getBio())
                 .birthday(birthday)
-                .favoriteColorId(friend.getPalette().getId())
+                .favoriteColorId(requestMember.getPalette().getId())
                 .build();
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
@@ -8,7 +8,7 @@ public class FriendshipResponse {
     @Getter
     @Builder
     public static class FriendRequestDto{
-        private String image;
+        private String profileImage;
         private String nickname;
         private String tag;
         private String bio;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
@@ -1,0 +1,16 @@
+package com.namo.spring.application.external.api.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FriendshipResponse {
+
+    @Getter
+    @Builder
+    public static class FriendRequestDto{
+        private String image;
+        private String nickname;
+        private String tag;
+        private String bio;
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
@@ -1,5 +1,7 @@
 package com.namo.spring.application.external.api.user.dto;
 
+import java.time.LocalDateTime;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,9 +10,12 @@ public class FriendshipResponse {
     @Getter
     @Builder
     public static class FriendRequestDto{
+        private Long memberId;
         private String profileImage;
         private String nickname;
         private String tag;
         private String bio;
+        private String birthday;
+        private Long favoriteColorId;
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
@@ -2,6 +2,8 @@ package com.namo.spring.application.external.api.user.dto;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,12 +12,21 @@ public class FriendshipResponse {
     @Getter
     @Builder
     public static class FriendRequestDto{
+        @Schema(description = "친구 요청 보낸 유저 ID", example = "4")
         private Long memberId;
+        @Schema(description = "친구요청 정보 ID", example = "2")
+        private Long friendRequestId;
+        @Schema(description = "친구 요청 유저 프로필 이미지", example = "https://static.namong.shop/resized/origin/member/image.png")
         private String profileImage;
+        @Schema(description = "친구 요청 유저 닉네임 ID", example = "2")
         private String nickname;
+        @Schema(description = "친구 요청 유저 태그", example = "1234")
         private String tag;
+        @Schema(description = "친구 요청 유저 한줄 소개", example = "3")
         private String bio;
+        @Schema(description = "친구 요청 유저 생일 (비공개 존재)", example = "02-22")
         private String birthday;
+        @Schema(description = "친구 요청 유저 선호 색", example = "2")
         private Long favoriteColorId;
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/MemberRequest.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/MemberRequest.java
@@ -79,5 +79,6 @@ public class MemberRequest {
         @NotNull(message = "색상 ID는 필수 값입니다.")
         private Long colorId;
         private String bio;
+        private String profileImage;
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/facade/AuthFacade.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/facade/AuthFacade.java
@@ -112,7 +112,8 @@ public class AuthFacade {
         Member member = memberManageService.getMember(memberId);
         String tag = tagGenerator.generateTag(member.getNickname());
         Palette palette = paletteService.getPalette(dto.getColorId());
-        member.signUpComplete(dto.getName(), dto.getNickname(), dto.getBirthday(), dto.getBio(), tag, palette);
+        member.signUpComplete(dto.getName(), dto.getNickname(), dto.getBirthday(), dto.getBio(), tag, palette,
+                dto.getProfileImage());
         memberManageService.saveMember(member);
         return member;
     }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/facade/AuthFacade.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/facade/AuthFacade.java
@@ -16,7 +16,7 @@ import com.namo.spring.application.external.api.user.dto.MemberResponse;
 import com.namo.spring.application.external.api.user.helper.JwtAuthHelper;
 import com.namo.spring.application.external.api.user.service.MemberManageService;
 import com.namo.spring.application.external.api.user.service.SocialLoginService;
-import com.namo.spring.application.external.api.user.service.TagGenerator;
+import com.namo.spring.application.external.global.utils.TagGenerator;
 import com.namo.spring.application.external.global.common.security.jwt.CustomJwts;
 import com.namo.spring.db.mysql.domains.category.entity.Palette;
 import com.namo.spring.db.mysql.domains.category.service.PaletteService;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/facade/AuthFacade.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/facade/AuthFacade.java
@@ -109,7 +109,7 @@ public class AuthFacade {
 
     @Transactional
     public Member completeSignup(MemberRequest.CompleteSignUpDto dto, Long memberId) {
-        Member member = memberManageService.getMember(memberId);
+        Member member = memberManageService.getPendingMember(memberId);
         String tag = tagGenerator.generateTag(member.getNickname());
         Palette palette = paletteService.getPalette(dto.getColorId());
         member.signUpComplete(dto.getName(), dto.getNickname(), dto.getBirthday(), dto.getBio(), tag, palette,

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/scheduler/MemberScheduler.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/scheduler/MemberScheduler.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.api.user.service;
+package com.namo.spring.application.external.api.user.scheduler;
 
 import java.util.List;
 
@@ -6,6 +6,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.namo.spring.application.external.api.user.service.MemberManageService;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 
 import lombok.RequiredArgsConstructor;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FriendManageService {
 
+    private static final Integer REQUEST_PAGE_SIZE = 20;
+
     private final FriendshipService friendshipService;
 
     /**
@@ -31,16 +33,17 @@ public class FriendManageService {
         if (friendshipService.existsByMemberIdAndFriendId(me.getId(), target.getId())){
             throw new MemberException(ErrorStatus.AlREADY_FRIENDSHIP_MEMBER);
         }
-        friendshipService.createFriendShip(FriendShipConverter.toFriendShip(me, target));
+        friendshipService.createFriendShip(FriendshipConverter.toFriendShip(me, target));
     }
 
     /**
-     * 친구 요청을 받은 목록을 조회하는 메서드입니다.
+     * 친구 요청을 받은 목록을 페이징하여 조회하는 메서드입니다.
      * !! PENDING 상태의 요청만 조회됩니다. (거절, 수락된 친구관계 조회 x)
-     * @param memberId
-     * @return
+     * @param memberId 요청을 받는 사용자의 ID
+     * @return PENDING 상태의 친구 요청 목록
      */
-    public List<Friendship> getReceivedFriendRequests(Long memberId) {
-        return friendshipService.readFriendshipByStatus(memberId, FriendshipStatus.PENDING);
+    public List<Friendship> getReceivedFriendRequests(Long memberId, int page) {
+        Pageable pageable = PageRequest.of(page - 1, REQUEST_PAGE_SIZE);
+        return friendshipService.readAllFriendshipByStatus(memberId, FriendshipStatus.PENDING, pageable);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -1,12 +1,16 @@
 package com.namo.spring.application.external.api.user.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.namo.spring.application.external.api.user.converter.FriendShipConverter;
 import com.namo.spring.core.common.code.status.ErrorStatus;
+import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 import com.namo.spring.db.mysql.domains.user.exception.MemberException;
 import com.namo.spring.db.mysql.domains.user.service.FriendshipService;
+import com.namo.spring.db.mysql.domains.user.type.FriendshipStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,5 +32,15 @@ public class FriendManageService {
             throw new MemberException(ErrorStatus.AlREADY_FRIENDSHIP_MEMBER);
         }
         friendshipService.createFriendShip(FriendShipConverter.toFriendShip(me, target));
+    }
+
+    /**
+     * 친구 요청을 받은 목록을 조회하는 메서드입니다.
+     * !! PENDING 상태의 요청만 조회됩니다. (거절, 수락된 친구관계 조회 x)
+     * @param memberId
+     * @return
+     */
+    public List<Friendship> getReceivedFriendRequests(Long memberId) {
+        return friendshipService.readFriendshipByStatus(memberId, FriendshipStatus.PENDING);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -68,6 +68,9 @@ public class FriendManageService {
     public void acceptRequest(Long memberId, Friendship friendship) {
         friendshipValidator.validateFriendshipToMember(friendship, memberId);
         friendship.accept();
+        Friendship reverse = friendshipService.createFriendShip(
+                FriendshipConverter.toFriendShip(friendship.getFriend(), friendship.getMember()));
+        reverse.accept();
     }
 
     /**

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -71,4 +71,16 @@ public class FriendManageService {
         }
         friendship.accept();
     }
+
+    /**
+     * 친구 요청을 거절하는 메서드입니다.
+     * @param memberId 요청을 받은 사람의 ID
+     * @param friendship 수락할 요청 건
+     */
+    public void rejectRequest(Long memberId, Friendship friendship) {
+        if (!friendship.getFriend().getId().equals(memberId)) {
+            throw new MemberException(ErrorStatus.NOT_MY_FRIENDSHIP_REQUEST);
+        }
+        friendship.reject();
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -1,0 +1,32 @@
+package com.namo.spring.application.external.api.user.service;
+
+import org.springframework.stereotype.Service;
+
+import com.namo.spring.application.external.api.user.converter.FriendShipConverter;
+import com.namo.spring.core.common.code.status.ErrorStatus;
+import com.namo.spring.db.mysql.domains.user.entity.Member;
+import com.namo.spring.db.mysql.domains.user.exception.MemberException;
+import com.namo.spring.db.mysql.domains.user.service.FriendshipService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FriendManageService {
+
+    private final FriendshipService friendshipService;
+
+    /**
+     * 친구 요청을 생성하는 메서드입니다.
+     * !! 이미 친구 요청 정보가 있는지 검증합니다.
+     * TODO: 알람 전송 구현이 필요합니다.
+     * @param me 요청을 보내는 사람
+     * @param target 친구 요청을 받는 사람
+     */
+    public void requestFriendShip(Member me, Member target) {
+        if (friendshipService.existsByMemberIdAndFriendId(me.getId(), target.getId())){
+            throw new MemberException(ErrorStatus.AlREADY_FRIENDSHIP_MEMBER);
+        }
+        friendshipService.createFriendShip(FriendShipConverter.toFriendShip(me, target));
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -2,9 +2,11 @@ package com.namo.spring.application.external.api.user.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import com.namo.spring.application.external.api.user.converter.FriendShipConverter;
+import com.namo.spring.application.external.api.user.converter.FriendshipConverter;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
@@ -37,7 +39,7 @@ public class FriendManageService {
     }
 
     /**
-     * 친구 요청을 받은 목록을 페이징하여 조회하는 메서드입니다.
+     * 나에게 온 친구 요청 목록을 페이징하여 조회하는 메서드입니다.
      * !! PENDING 상태의 요청만 조회됩니다. (거절, 수락된 친구관계 조회 x)
      * @param memberId 요청을 받는 사용자의 ID
      * @return PENDING 상태의 친구 요청 목록
@@ -45,5 +47,28 @@ public class FriendManageService {
     public List<Friendship> getReceivedFriendRequests(Long memberId, int page) {
         Pageable pageable = PageRequest.of(page - 1, REQUEST_PAGE_SIZE);
         return friendshipService.readAllFriendshipByStatus(memberId, FriendshipStatus.PENDING, pageable);
+    }
+
+    /**
+     * 단일 PENDING 친구 요청을 조회하는 메서드입니다.
+     * @param friendshipId 친구 요청 ID
+     * @return PENDING 상태의 친구 요청
+     */
+    public Friendship getPendingFriendship(Long friendshipId) {
+        return friendshipService.readFriendshipByStatus(friendshipId, FriendshipStatus.PENDING)
+                .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_FRIENDSHIP_REQUEST));
+    }
+
+    /**
+     * 친구 요청을 수락하는 메서입니다.
+     * !! 나에게 온 요청이 맞는지 검증합니다.
+     * @param memberId 수락할 사람 ID
+     * @param friendship 수락할 요청 건
+     */
+    public void acceptRequest(Long memberId, Friendship friendship) {
+        if (!friendship.getFriend().getId().equals(memberId)){
+            throw new MemberException(ErrorStatus.NOT_MY_FRIENDSHIP_REQUEST);
+        }
+        friendship.accept();
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -71,13 +71,13 @@ public class FriendManageService {
     }
 
     /**
-     * 친구 요청을 거절하는 메서드입니다.
+     * 친구 요청을 거절하는 메서드입니다. (친구 요청 자체가 삭제됩니다)
      * !! 나에게 온 요청이 맞는지 검증합니다.
      * @param memberId 요청을 받은 사람의 ID
      * @param friendship 수락할 요청 건
      */
     public void rejectRequest(Long memberId, Friendship friendship) {
         friendshipValidator.validateFriendshipToMember(friendship, memberId);
-        friendship.reject();
+        friendshipService.delete(friendship);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/MemberManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/MemberManageService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import com.namo.spring.application.external.api.category.service.CategoryMaker;
 import com.namo.spring.application.external.api.user.converter.MemberConverter;
 import com.namo.spring.application.external.api.user.dto.MemberDto;
+import com.namo.spring.application.external.global.utils.NicknameTag;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.db.mysql.domains.user.entity.Anonymous;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
@@ -47,6 +48,12 @@ public class MemberManageService {
 
     public Member getActiveMember(Long memberId){
         return memberService.readMemberByStatus(memberId, MemberStatus.ACTIVE)
+                .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_ACTIVE_USER_FAILURE));
+    }
+
+    public Member getActiveMemberByNicknameTag(String nicknameTag){
+        NicknameTag findTarget = NicknameTag.from(nicknameTag);
+        return memberService.readMemberByStatus(findTarget.getNickname(), findTarget.getTag(), MemberStatus.ACTIVE)
                 .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_ACTIVE_USER_FAILURE));
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/MemberManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/MemberManageService.java
@@ -45,12 +45,13 @@ public class MemberManageService {
                 .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_USER_FAILURE));
     }
 
-    public Optional<Member> getMemberByEmailAndSocialType(String email, SocialType socialType) {
-        return memberRepository.findMemberByEmailAndSocialType(email, socialType);
+    public Member getActiveMember(Long memberId){
+        return memberService.readMemberByStatus(memberId, MemberStatus.ACTIVE)
+                .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_ACTIVE_USER_FAILURE));
     }
 
-    public Optional<Member> getMemberAuthId(String authId) {
-        return memberRepository.findMemberByAuthId(authId);
+    public Optional<Member> getMemberByEmailAndSocialType(String email, SocialType socialType) {
+        return memberRepository.findMemberByEmailAndSocialType(email, socialType);
     }
 
     public List<Member> getInactiveMember() {

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/MemberManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/MemberManageService.java
@@ -50,6 +50,11 @@ public class MemberManageService {
                 .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_ACTIVE_USER_FAILURE));
     }
 
+    public Member getPendingMember(Long memberId){
+        return memberService.readMemberByStatus(memberId, MemberStatus.PENDING)
+                .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_PENDING_USER_FAILURE));
+    }
+
     public Optional<Member> getMemberByEmailAndSocialType(String email, SocialType socialType) {
         return memberRepository.findMemberByEmailAndSocialType(email, socialType);
     }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -1,0 +1,11 @@
+package com.namo.spring.application.external.api.user.usecase;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FriendUseCase {
+
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.namo.spring.application.external.api.user.converter.FriendShipConverter;
+import com.namo.spring.application.external.api.user.converter.FriendshipConverter;
 import com.namo.spring.application.external.api.user.dto.FriendshipResponse;
 import com.namo.spring.application.external.api.user.service.FriendManageService;
 import com.namo.spring.application.external.api.user.service.MemberManageService;
@@ -34,5 +34,11 @@ public class FriendUseCase {
         return receivedRequests.stream()
                 .map(FriendshipConverter::toFriendRequestDto)
                 .toList();
+    }
+
+    @Transactional
+    public void acceptRequest(Long memberId, Long friendshipId) {
+        Friendship friendship = friendManageService.getPendingFriendship(friendshipId);
+        friendManageService.acceptRequest(memberId, friendship);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -23,8 +23,8 @@ public class FriendUseCase {
 
     @Transactional
     public void requestFriendship(Long myMemberId, Long targetMemberId) {
-        Member me = memberManageService.getMember(myMemberId);
-        Member friend = memberManageService.getMember(targetMemberId);
+        Member me = memberManageService.getActiveMember(myMemberId);
+        Member friend = memberManageService.getActiveMember(targetMemberId);
         friendManageService.requestFriendShip(me, friend);
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -29,10 +29,10 @@ public class FriendUseCase {
     }
 
     @Transactional(readOnly = true)
-    public List<FriendshipResponse.FriendRequestDto> getFriendshipRequest(Long memberId) {
-        List<Friendship> receivedRequests = friendManageService.getReceivedFriendRequests(memberId);
+    public List<FriendshipResponse.FriendRequestDto> getFriendshipRequest(Long memberId, int page) {
+        List<Friendship> receivedRequests = friendManageService.getReceivedFriendRequests(memberId, page);
         return receivedRequests.stream()
-                .map(FriendShipConverter::toFriendRequestDto)
+                .map(FriendshipConverter::toFriendRequestDto)
                 .toList();
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -1,10 +1,15 @@
 package com.namo.spring.application.external.api.user.usecase;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.namo.spring.application.external.api.user.converter.FriendShipConverter;
+import com.namo.spring.application.external.api.user.dto.FriendshipResponse;
 import com.namo.spring.application.external.api.user.service.FriendManageService;
 import com.namo.spring.application.external.api.user.service.MemberManageService;
+import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -21,5 +26,13 @@ public class FriendUseCase {
         Member me = memberManageService.getMember(myMemberId);
         Member friend = memberManageService.getMember(targetMemberId);
         friendManageService.requestFriendShip(me, friend);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FriendshipResponse.FriendRequestDto> getFriendshipRequest(Long memberId) {
+        List<Friendship> receivedRequests = friendManageService.getReceivedFriendRequests(memberId);
+        return receivedRequests.stream()
+                .map(FriendShipConverter::toFriendRequestDto)
+                .toList();
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -1,6 +1,11 @@
 package com.namo.spring.application.external.api.user.usecase;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.namo.spring.application.external.api.user.service.FriendManageService;
+import com.namo.spring.application.external.api.user.service.MemberManageService;
+import com.namo.spring.db.mysql.domains.user.entity.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -8,4 +13,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FriendUseCase {
 
+    private final MemberManageService memberManageService;
+    private final FriendManageService friendManageService;
+
+    @Transactional
+    public void requestFriendship(Long myMemberId, Long targetMemberId) {
+        Member me = memberManageService.getMember(myMemberId);
+        Member friend = memberManageService.getMember(targetMemberId);
+        friendManageService.requestFriendShip(me, friend);
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -41,4 +41,10 @@ public class FriendUseCase {
         Friendship friendship = friendManageService.getPendingFriendship(friendshipId);
         friendManageService.acceptRequest(memberId, friendship);
     }
+
+    @Transactional
+    public void rejectFriendRequest(Long memberId, Long friendshipId) {
+        Friendship friendship = friendManageService.getPendingFriendship(friendshipId);
+        friendManageService.rejectRequest(memberId, friendship);
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -22,9 +22,9 @@ public class FriendUseCase {
     private final FriendManageService friendManageService;
 
     @Transactional
-    public void requestFriendship(Long myMemberId, Long targetMemberId) {
+    public void requestFriendship(Long myMemberId, String nicknameTag) {
         Member me = memberManageService.getActiveMember(myMemberId);
-        Member friend = memberManageService.getActiveMember(targetMemberId);
+        Member friend = memberManageService.getActiveMemberByNicknameTag(nicknameTag);
         friendManageService.requestFriendShip(me, friend);
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/FriendshipValidator.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/FriendshipValidator.java
@@ -1,0 +1,30 @@
+package com.namo.spring.application.external.global.utils;
+
+import org.springframework.stereotype.Component;
+
+import com.namo.spring.core.common.code.status.ErrorStatus;
+import com.namo.spring.db.mysql.domains.user.entity.Friendship;
+import com.namo.spring.db.mysql.domains.user.entity.Member;
+import com.namo.spring.db.mysql.domains.user.exception.MemberException;
+import com.namo.spring.db.mysql.domains.user.service.FriendshipService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FriendshipValidator {
+
+    private final FriendshipService friendshipService;
+
+    public void validateAlreadyFriendship(Member me, Member target) {
+        if (friendshipService.existsByMemberIdAndFriendId(me.getId(), target.getId())) {
+            throw new MemberException(ErrorStatus.AlREADY_FRIENDSHIP_MEMBER);
+        }
+    }
+
+    public void validateFriendshipToMember(Friendship friendship, Long memberId) {
+        if (!friendship.getFriend().getId().equals(memberId)) {
+            throw new MemberException(ErrorStatus.NOT_MY_FRIENDSHIP_REQUEST);
+        }
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/FriendshipValidator.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/FriendshipValidator.java
@@ -16,12 +16,23 @@ public class FriendshipValidator {
 
     private final FriendshipService friendshipService;
 
+    /**
+     * 이미 요청 보낸경우, 이미 요청 받은 경우, 이미 친구인 경우를 검증합니다.
+     * @param me
+     * @param target
+     */
     public void validateAlreadyFriendship(Member me, Member target) {
-        if (friendshipService.existsByMemberIdAndFriendId(me.getId(), target.getId())) {
+        if (friendshipService.existsByMemberIdAndFriendId(me.getId(), target.getId()) ||
+                friendshipService.existsByMemberIdAndFriendId(target.getId(), me.getId())) {
             throw new MemberException(ErrorStatus.AlREADY_FRIENDSHIP_MEMBER);
         }
     }
 
+    /**
+     * 나에게 온 친구요청인지를 검증합니다.
+     * @param friendship
+     * @param memberId
+     */
     public void validateFriendshipToMember(Friendship friendship, Long memberId) {
         if (!friendship.getFriend().getId().equals(memberId)) {
             throw new MemberException(ErrorStatus.NOT_MY_FRIENDSHIP_REQUEST);

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/NicknameTag.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/NicknameTag.java
@@ -1,0 +1,40 @@
+package com.namo.spring.application.external.global.utils;
+
+import com.namo.spring.core.common.code.status.ErrorStatus;
+import com.namo.spring.db.mysql.domains.user.exception.MemberException;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NicknameTag {
+
+    private static final int NICKNAME_TAG_PARTS = 2;
+    private static final int TAG_LENGTH = 4;
+    private static final String NICKNAME_TAG_SEPARATOR = "#";
+    private static final String TAG_PATTERN = "\\d{4}";
+
+    private final String nickname;
+    private final String tag;
+
+
+    public static NicknameTag from(String nicknameTag) {
+        String[] parts = nicknameTag.split(NICKNAME_TAG_SEPARATOR);
+        validateParts(parts);
+        return new NicknameTag(parts[0], parts[1]);
+    }
+
+    private static void validateParts(String[] parts) {
+        if (parts.length != NICKNAME_TAG_PARTS) {
+            throw new MemberException(ErrorStatus.INVALID_NICKNAME_TAG_FORMAT);
+        }
+        if (parts[0].isEmpty()) {
+            throw new MemberException(ErrorStatus.INVALID_NICKNAME_TAG_FORMAT);
+        }
+        if (parts[1].length() != TAG_LENGTH && !parts[1].matches(TAG_PATTERN)) {
+            throw new MemberException(ErrorStatus.INVALID_TAG_FORMAT);
+        }
+    }
+
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/TagGenerator.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/TagGenerator.java
@@ -1,10 +1,12 @@
-package com.namo.spring.application.external.api.user.service;
+package com.namo.spring.application.external.global.utils;
 
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
 import org.springframework.stereotype.Component;
+
+import com.namo.spring.application.external.api.user.service.MemberManageService;
 
 import lombok.RequiredArgsConstructor;
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/TagGenerator.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/global/utils/TagGenerator.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import org.springframework.stereotype.Component;
 
 import com.namo.spring.application.external.api.user.service.MemberManageService;
+import com.namo.spring.core.common.code.status.ErrorStatus;
+import com.namo.spring.db.mysql.domains.user.exception.MemberException;
 
 import lombok.RequiredArgsConstructor;
 

--- a/application/external-api-v2/src/test/java/com/namo/spring/application/external/api/user/service/TagGeneratorTest.java
+++ b/application/external-api-v2/src/test/java/com/namo/spring/application/external/api/user/service/TagGeneratorTest.java
@@ -12,6 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.namo.spring.application.external.global.utils.TagGenerator;
+
 public class TagGeneratorTest {
 
     @Mock

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -104,6 +104,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     NOT_FOUND_ACTIVE_USER_FAILURE(HttpStatus.NOT_FOUND, "활성화된 유저를 찾을 수 없습니다. (가입되지 않은 유저거나, 회원가입이 완료되지 않았습니다.)"),
 
+    NOT_FOUND_PENDING_USER_FAILURE(HttpStatus.NOT_FOUND, "회원가입 대기중인 유저를 찾을 수 없습니다. (가입되지 않은 유저거나, 이미 가입이 완료되었습니다.)"),
+
     NOT_FOUND_SCHEDULE_FAILURE(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다. (참여한 일정이 아니거나, 일정 정보가 없습니다)"),
 
     NOT_FOUND_PARTICIPANT_FAILURE(HttpStatus.NOT_FOUND, "일정의 참여자를 찾을 수 없습니다. (모임 스케줄의 경우 초대에 수락하지 않았을 수 있습니다"),

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -40,6 +40,8 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_MEETING_PARTICIPANT(HttpStatus.BAD_REQUEST, "중복되는 참여자입니다."),
     INVALID_MEETING_PARTICIPANT_COUNT(HttpStatus.BAD_REQUEST, "모임 일정은 최소 1명, 최대 9명까지 초대 가능합니다."),
     CATEGORY_IN_USE_FAILURE(HttpStatus.BAD_REQUEST, "사용중인 카테고리는 삭제할 수 없습니다."),
+    INVALID_NICKNAME_TAG_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 닉네임#태그형식입니다."),
+    INVALID_TAG_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 태그 형식입니다."),
 
     /**
      * 401 : 소셜 로그인 오류

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -102,6 +102,8 @@ public enum ErrorStatus implements BaseErrorCode {
      */
     NOT_FOUND_USER_FAILURE(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
 
+    NOT_FOUND_ACTIVE_USER_FAILURE(HttpStatus.NOT_FOUND, "활성화된 유저를 찾을 수 없습니다. (가입되지 않은 유저거나, 회원가입이 완료되지 않았습니다.)"),
+
     NOT_FOUND_SCHEDULE_FAILURE(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다. (참여한 일정이 아니거나, 일정 정보가 없습니다)"),
 
     NOT_FOUND_PARTICIPANT_FAILURE(HttpStatus.NOT_FOUND, "일정의 참여자를 찾을 수 없습니다. (모임 스케줄의 경우 초대에 수락하지 않았을 수 있습니다"),

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -83,6 +83,8 @@ public enum ErrorStatus implements BaseErrorCode {
     /**
      * 403 : 리소스 접근 권한 오류
      */
+    AlREADY_FRIENDSHIP_MEMBER(HttpStatus.BAD_REQUEST, "이미 처리된 친구 요청이거나 친구입니다."),
+
     NOT_FRIENDSHIP_MEMBER(HttpStatus.BAD_REQUEST, "요청한 회원과 친구가 아닙니다."),
 
     NOT_SCHEDULE_OWNER(HttpStatus.FORBIDDEN, "해당 일정의 생성자가 아닙니다."),

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -85,6 +85,8 @@ public enum ErrorStatus implements BaseErrorCode {
      */
     AlREADY_FRIENDSHIP_MEMBER(HttpStatus.BAD_REQUEST, "이미 처리된 친구 요청이거나 친구입니다."),
 
+    NOT_MY_FRIENDSHIP_REQUEST(HttpStatus.BAD_REQUEST, "나에게 요청온 친구 요청이 아닙니다."),
+
     NOT_FRIENDSHIP_MEMBER(HttpStatus.BAD_REQUEST, "요청한 회원과 친구가 아닙니다."),
 
     NOT_SCHEDULE_OWNER(HttpStatus.FORBIDDEN, "해당 일정의 생성자가 아닙니다."),
@@ -138,6 +140,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     NOT_PARTICIPATING_ACTIVITY(HttpStatus.NOT_FOUND, "참여한 활동이 아닙니다." ),
 
+    NOT_FOUND_FRIENDSHIP_REQUEST(HttpStatus.NOT_FOUND, "친구 요청을 찾을 수 없습니다."),
     /**
      * 404 : 예외 상황 에러
      */

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -85,7 +85,7 @@ public enum ErrorStatus implements BaseErrorCode {
     /**
      * 403 : 리소스 접근 권한 오류
      */
-    AlREADY_FRIENDSHIP_MEMBER(HttpStatus.BAD_REQUEST, "이미 처리된 친구 요청이거나 친구입니다."),
+    AlREADY_FRIENDSHIP_MEMBER(HttpStatus.BAD_REQUEST, "이미 진행중인 친구 요청이거나 친구입니다."),
 
     NOT_MY_FRIENDSHIP_REQUEST(HttpStatus.BAD_REQUEST, "나에게 요청온 친구 요청이 아닙니다."),
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Friendship.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Friendship.java
@@ -61,4 +61,7 @@ public class Friendship extends BaseTimeEntity {
         this.isFavorite = false;
     }
 
+    public void accept() {
+        status = ACCEPTED;
+    }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Friendship.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Friendship.java
@@ -1,5 +1,7 @@
 package com.namo.spring.db.mysql.domains.user.entity;
 
+import static com.namo.spring.db.mysql.domains.user.type.FriendshipStatus.*;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -44,10 +46,10 @@ public class Friendship extends BaseTimeEntity {
     private FriendshipStatus status;
 
     @Builder
-    public Friendship(Member member, Member friend, FriendshipStatus status) {
+    public Friendship(Member member, Member friend) {
         this.member = member;
         this.friend = friend;
-        this.status = status;
+        this.status = PENDING;
         this.isFavorite = false;
     }
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Friendship.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Friendship.java
@@ -64,4 +64,7 @@ public class Friendship extends BaseTimeEntity {
     public void accept() {
         status = ACCEPTED;
     }
+    public void reject() {
+        status = REJECTED;
+    }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
@@ -166,7 +166,8 @@ public class Member extends BaseTimeEntity implements User {
         return !status.equals(MemberStatus.PENDING);
     }
 
-    public void signUpComplete(String name, String nickname, String birthday, String bio, String tag, Palette palette) {
+    public void signUpComplete(String name, String nickname, String birthday, String bio, String tag, Palette palette,
+            String profileImage) {
         this.name = name;
         this.nickname = nickname;
         this.birthday = birthday;
@@ -174,5 +175,6 @@ public class Member extends BaseTimeEntity implements User {
         this.tag = tag;
         this.palette = palette;
         this.status = MemberStatus.ACTIVE;
+        this.profileImage = profileImage;
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
@@ -73,6 +73,8 @@ public class Member extends BaseTimeEntity implements User {
     @Column(length = 4)
     private String tag;
 
+    private String profileImage;
+
     @JdbcTypeCode(SqlTypes.VARCHAR)
     @Column(length = 10)
     private String birthday;  // "MM-DD"

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
@@ -1,7 +1,9 @@
 package com.namo.spring.db.mysql.domains.user.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,7 +16,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
 
     boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
 
-    List<Friendship> findAllByMemberIdAndStatus(Long memberId, FriendshipStatus status, Pageable pageable);
+    List<Friendship> findAllByFriendIdAndStatus(Long memberId, FriendshipStatus status, Pageable pageable);
 
-    Friendship findByMemberIdAndStatus(Long friendshipId, FriendshipStatus status);
+    Optional<Friendship> findByIdAndStatus(Long friendshipId, FriendshipStatus status);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
@@ -14,5 +14,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
 
     boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
 
-    List<Friendship> findAllByMemberIdAndStatus(Long memberId, FriendshipStatus status);
+    List<Friendship> findAllByMemberIdAndStatus(Long memberId, FriendshipStatus status, Pageable pageable);
+
+    Friendship findByMemberIdAndStatus(Long friendshipId, FriendshipStatus status);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
+import com.namo.spring.db.mysql.domains.user.type.FriendshipStatus;
 
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     @Query("SELECT DISTINCT f FROM Friendship f JOIN FETCH f.friend WHERE f.member.id = :memberId AND f.friend.id in :members AND f.status = 'ACCEPTED' AND f.member.status = '2'")
     List<Friendship> findAcceptedFriendshipsByMemberIdAndFriendIds(Long memberId, List<Long> members);
 
     boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
+
+    List<Friendship> findAllByMemberIdAndStatus(Long memberId, FriendshipStatus status);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/MemberRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/MemberRepository.java
@@ -29,4 +29,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findMembersByNickname(String nickname);
 
     boolean existsByEmailAndSocialType(String email, SocialType socialType);
+
+    Optional<Member> findByIdAndStatus(Long memberId, MemberStatus status);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/MemberRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/MemberRepository.java
@@ -31,4 +31,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmailAndSocialType(String email, SocialType socialType);
 
     Optional<Member> findByIdAndStatus(Long memberId, MemberStatus status);
+
+    Optional<Member> findByNicknameAndTagAndStatus(String nickname, String tag, MemberStatus status);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.namo.spring.core.common.annotation.DomainService;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.repository.FriendshipRepository;
+import com.namo.spring.db.mysql.domains.user.type.FriendshipStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,5 +24,9 @@ public class FriendshipService {
 
     public void createFriendShip(Friendship friendship){
         friendshipRepository.save(friendship);
+    }
+
+    public List<Friendship> readFriendshipByStatus(Long memberId, FriendshipStatus status) {
+        return friendshipRepository.findAllByMemberIdAndStatus(memberId, status);
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -26,7 +26,7 @@ public class FriendshipService {
         friendshipRepository.save(friendship);
     }
 
-    public List<Friendship> readFriendshipByStatus(Long memberId, FriendshipStatus status) {
-        return friendshipRepository.findAllByMemberIdAndStatus(memberId, status);
+    public List<Friendship> readAllFriendshipByStatus(Long memberId, FriendshipStatus status, Pageable pageable) {
+        return friendshipRepository.findAllByMemberIdAndStatus(memberId, status, pageable);
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -1,6 +1,9 @@
 package com.namo.spring.db.mysql.domains.user.service;
 
 import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
 
 import com.namo.spring.core.common.annotation.DomainService;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
@@ -27,6 +30,10 @@ public class FriendshipService {
     }
 
     public List<Friendship> readAllFriendshipByStatus(Long memberId, FriendshipStatus status, Pageable pageable) {
-        return friendshipRepository.findAllByMemberIdAndStatus(memberId, status, pageable);
+        return friendshipRepository.findAllByFriendIdAndStatus(memberId, status, pageable);
+    }
+
+    public Optional<Friendship> readFriendshipByStatus(Long friendshipId, FriendshipStatus status){
+        return friendshipRepository.findByIdAndStatus(friendshipId, status);
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -25,8 +25,8 @@ public class FriendshipService {
         return friendshipRepository.existsByMemberIdAndFriendId(memberId, friendId);
     }
 
-    public void createFriendShip(Friendship friendship){
-        friendshipRepository.save(friendship);
+    public Friendship createFriendShip(Friendship friendship){
+        return friendshipRepository.save(friendship);
     }
 
     public List<Friendship> readAllFriendshipByStatus(Long memberId, FriendshipStatus status, Pageable pageable) {

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -36,4 +36,8 @@ public class FriendshipService {
     public Optional<Friendship> readFriendshipByStatus(Long friendshipId, FriendshipStatus status){
         return friendshipRepository.findByIdAndStatus(friendshipId, status);
     }
+
+    public void delete(Friendship friendship) {
+        friendshipRepository.delete(friendship);
+    }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -20,4 +20,8 @@ public class FriendshipService {
     public boolean existsByMemberIdAndFriendId(Long memberId, Long friendId) {
         return friendshipRepository.existsByMemberIdAndFriendId(memberId, friendId);
     }
+
+    public void createFriendShip(Friendship friendship){
+        friendshipRepository.save(friendship);
+    }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/MemberService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/MemberService.java
@@ -28,22 +28,11 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public List<Member> readActiveMembersById(List<Long> memberIds) {
-        return memberRepository.findMembersByIdInAndStatusIs(memberIds, MemberStatus.ACTIVE);
-    }
-
-    @Transactional
-    public void deleteMember(Long memberId) {
-        memberRepository.deleteById(memberId);
-    }
-
-    @Transactional
-    public void deleteMember(Member member) {
-        memberRepository.delete(member);
-    }
-
-    @Transactional(readOnly = true)
     public List<Member> readMemberByNickname(String nickname) {
         return memberRepository.findMembersByNickname(nickname);
+    }
+
+    public Optional<Member> readMemberByStatus(Long memberId, MemberStatus status){
+        return memberRepository.findByIdAndStatus(memberId, status);
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/MemberService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/MemberService.java
@@ -35,4 +35,8 @@ public class MemberService {
     public Optional<Member> readMemberByStatus(Long memberId, MemberStatus status){
         return memberRepository.findByIdAndStatus(memberId, status);
     }
+
+    public Optional<Member> readMemberByStatus(String nickname, String tag, MemberStatus status){
+        return memberRepository.findByNicknameAndTagAndStatus(nickname, tag, status);
+    }
 }

--- a/storage/db-mysql-v2/src/main/resources/db/migration/dev/V1.0.9__Add_columns_to_member_table.sql
+++ b/storage/db-mysql-v2/src/main/resources/db/migration/dev/V1.0.9__Add_columns_to_member_table.sql
@@ -1,0 +1,5 @@
+-- v1.0.9__Add_columns_to_member_table
+
+-- 유저 프로필 이미지 컬럼 추가
+ALTER TABLE member
+    ADD COLUMN profile_image VARCHAR(255);


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [X] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 친구 요청 관련 기능 구현 
  - 조회, 요청, 수락, 거절
  - 수락시 양방향 관계 생성
 
- 유저 조회 로직 분리
  - ACTIVE, PENDING 유저를 비즈니스 로직에서 분리해 조회하도록 구현
  
- 유저 프로필 이미지 생성
  - flyway 적용
  - 회원가입 완료시 프로필이미지 저장

- NicknameTag.class 생성
  - nickname#tag를 캡슐화하여 검증하고 분리할 수 있는 메서드 생성

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- NicknameTag.class 사용 부분
- 각 ManageService(비즈니스 로직)
위주로 보시면 됩니다.

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- flyway 강제 적용 법

### 고민 했던 사항

- 비즈니스 로직에서 각 상태나 page객체를 만들어 도메인 로직으로 주입해 사용
  - 조회될 엔티티의 상태나, page 여부는 비즈니스 룰에 의해 결정되기 때문에 manage Service(비즈니스 서비스) 단에 위임

### 추후 작업 사항

- 친구 요청, 수락 시 알람 구현


## 첨부 자료

<img width="667" alt="image" src="https://github.com/user-attachments/assets/6b65fbca-1876-41af-9322-648ec3f40260">
<img width="755" alt="image" src="https://github.com/user-attachments/assets/40740157-3cd2-47ce-91e7-07b17cb65e93">


## 관련 이슈

- close #325
