### PR TITLE
[Feature/327] 상단 스케줄 조회에 참여자 정보, 명수 추가 (+ 모임 수락시 즉시 참여 변경)

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/ScheduleConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/ScheduleConverter.java
@@ -1,5 +1,7 @@
 package com.namo.spring.application.external.api.schedule.converter;
 
+import java.util.List;
+
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
 import com.namo.spring.application.external.api.schedule.dto.ScheduleResponse;
 import com.namo.spring.db.mysql.domains.category.entity.Category;
@@ -38,7 +40,9 @@ public class ScheduleConverter {
                 .categoryInfo(toCategoryInfoDto(participant.getCategory()))
                 .hasDiary(participant.isHasDiary())
                 .participantCount(schedule.getParticipantCount())
-                .participantInfo(toParticipantInfoDto(participant))
+                .participantInfo(schedule.getParticipantList().stream()
+                        .map(ScheduleConverter::toParticipantInfoDto)
+                        .toList())
                 .build();
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/ScheduleConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/ScheduleConverter.java
@@ -6,6 +6,8 @@ import com.namo.spring.db.mysql.domains.category.entity.Category;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.type.Period;
+import com.namo.spring.db.mysql.domains.user.entity.Member;
+import com.namo.spring.db.mysql.domains.user.entity.User;
 
 public class ScheduleConverter {
     private ScheduleConverter() {
@@ -35,6 +37,8 @@ public class ScheduleConverter {
                 .locationInfo(LocationConverter.toLocationInfoDto(schedule.getLocation()))
                 .categoryInfo(toCategoryInfoDto(participant.getCategory()))
                 .hasDiary(participant.isHasDiary())
+                .participantCount(schedule.getParticipantCount())
+                .participantInfo(toParticipantInfoDto(participant))
                 .build();
     }
 
@@ -42,6 +46,16 @@ public class ScheduleConverter {
         return ScheduleResponse.CategoryInfoDto.builder()
                 .name(category.getName())
                 .colorId(category.getPalette().getId())
+                .build();
+    }
+
+    private static ScheduleResponse.ParticipantInfoDto toParticipantInfoDto(Participant participant){
+        User user = participant.getUser();
+        boolean isMember = user instanceof Member;
+        return ScheduleResponse.ParticipantInfoDto.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .isMember(isMember)
                 .build();
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/ScheduleResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/ScheduleResponse.java
@@ -1,6 +1,7 @@
 package com.namo.spring.application.external.api.schedule.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -26,7 +27,7 @@ public class ScheduleResponse {
         private LocalDateTime scheduleStartDate;
         private LocationInfoDto locationInfo;
         private CategoryInfoDto categoryInfo;
-        private ParticipantInfoDto participantInfo;
+        private List<ParticipantInfoDto> participantInfo;
         private int participantCount;
         private boolean hasDiary;
     }
@@ -61,7 +62,7 @@ public class ScheduleResponse {
         private Long userId;
         @Schema(description = "유저 이름", example = "캐슬")
         private String nickname;
-        @Schema(description = "회원 여부", example = "true")
+        @Schema(description = "회원 여부 (true: 회원/ false: 비회원) ", example = "true")
         private boolean isMember;
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/ScheduleResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/ScheduleResponse.java
@@ -26,6 +26,8 @@ public class ScheduleResponse {
         private LocalDateTime scheduleStartDate;
         private LocationInfoDto locationInfo;
         private CategoryInfoDto categoryInfo;
+        private ParticipantInfoDto participantInfo;
+        private int participantCount;
         private boolean hasDiary;
     }
 
@@ -48,6 +50,19 @@ public class ScheduleResponse {
         private String name;
         @Schema(description = "카테고리 색상", example = "1")
         private Long colorId;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "참여자 정보 DTO")
+    public static class ParticipantInfoDto{
+        @Schema(description = "유저 ID (회원일 경우 memberId, 비회원인 경우 AnonymousId)", example = "2")
+        private Long userId;
+        @Schema(description = "유저 이름", example = "캐슬")
+        private String nickname;
+        @Schema(description = "회원 여부", example = "true")
+        private boolean isMember;
     }
 
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantMaker.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipantMaker.java
@@ -49,8 +49,9 @@ public class ParticipantMaker {
     public void makeMeetingScheduleParticipants(Schedule schedule, List<Member> members) {
         List<Participant> participants = members.stream()
                 .map(member -> Participant.of(ParticipantRole.NON_OWNER.getValue(), member, schedule,
-                        ParticipantStatus.INACTIVE, null, null, null, null))
+                        ParticipantStatus.ACTIVE, null, null, schedule.getTitle(), schedule.getImageUrl()))
                 .collect(Collectors.toList());
+        members.forEach(member -> schedule.addActiveParticipant(member.getNickname()));
         participantService.createParticipants(participants);
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipationActionManager.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ParticipationActionManager.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class ParticipationActionManager {
+    // todo : 기획 변경에 따라 활동 초대 수락, 거절이 없어짐 -> 미사용 class
     private final CategoryService categoryService;
     private final PaletteService paletteService;
     private final ParticipantService participantService;


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [X] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 기획 변경에 따라 모임에 포함되어 생성될 시 즉시 참여됩니다. 
  - 즉시 ACTIVE 상태
  - Schedule 안에 count, names에 즉시 추가

- 기록 상단 스케줄 조회에 참여자 정보가 추가되었습니다.
  - 참여 명수 추가
  - 참여자 정보 추가
    - userId, nickname, isMember 값

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

<img width="751" alt="image" src="https://github.com/user-attachments/assets/21a38f61-b22c-4e16-9b11-395e09b361ca">


## 관련 이슈

- close #327 
