### PR TITLE
[Bug/329]  활동 조회에 이미지값 누락 수정

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/ActivityResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/ActivityResponseConverter.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import com.namo.spring.application.external.api.record.dto.ActivityResponse;
 import com.namo.spring.db.mysql.domains.record.entity.Activity;
+import com.namo.spring.db.mysql.domains.record.entity.ActivityImage;
 import com.namo.spring.db.mysql.domains.record.entity.ActivityParticipant;
 import com.namo.spring.db.mysql.domains.schedule.type.Location;
 
@@ -24,6 +25,9 @@ public class ActivityResponseConverter {
                 .activityEndDate(activity.getEndDate())
                 .activityLocation(toActivityLocationDto(activity.getSchedule().getLocation()))
                 .totalAmount(activity.getTotalAmount())
+                .activityImages(activity.getActivityImages().stream()
+                        .map(ActivityResponseConverter::toActivityImageDto)
+                        .toList())
                 .tag(activity.getCategoryTag())
                 .build();
     }
@@ -70,6 +74,14 @@ public class ActivityResponseConverter {
                 .activityParticipantId(activityParticipant.getParticipant().getId())
                 .participantNickname(activityParticipant.getParticipant().getMember().getNickname())
                 .isIncludedInSettlement(activityParticipant.isIncludedInSettlement())
+                .build();
+    }
+
+    public static ActivityResponse.ActivityImageDto toActivityImageDto(ActivityImage image){
+        return ActivityResponse.ActivityImageDto.builder()
+                .activityImageId(image.getId())
+                .imageUrl(image.getImageUrl())
+                .orderNumber(image.getImageOrder())
                 .build();
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/ActivityResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/ActivityResponse.java
@@ -24,6 +24,7 @@ public class ActivityResponse {
         private LocalDateTime activityEndDate;
         private ActivityLocationDto activityLocation;
         private BigDecimal totalAmount;
+        private List<ActivityImageDto> activityImages;
         private String tag;
     }
 
@@ -69,5 +70,18 @@ public class ActivityResponse {
         private Long activityParticipantId;
         private String participantNickname;
         private boolean isIncludedInSettlement;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "활동 이미지 정보 DTO")
+    public static class ActivityImageDto {
+        @Schema(description = "정렬 순서", example = "1")
+        private Integer orderNumber;
+        @Schema(description = "이미지 ID", example = "34")
+        private Long activityImageId;
+        @Schema(description = "이미지 URL", example = "https://static.namong.shop/resized/origin/acitivity/image.png")
+        private String imageUrl;
     }
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [X] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 활동 조회시 누락된 이미지 값이 포함됩니다.


## 첨부 자료

<img width="599" alt="image" src="https://github.com/user-attachments/assets/1a2502d6-2944-4e7b-8e82-9034fee81cfa">


## 관련 이슈

- close #329 
