### PR TITLE
[Feature/382] 나의 친구목록을 조회하는 API 구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -90,4 +90,12 @@ public class FriendController {
         return ResponseDto.onSuccess("친구 요청을 거절했습니다.");
     }
 
+    @Operation(summary = "내 친구 목록을 조회합니다.", description = "내 친구 리스트를 보는 API 입니다.")
+    @GetMapping("")
+    public ResponseDto<List<FriendshipResponse.FriendInfoDto>> getFriendList(
+            @AuthenticationPrincipal SecurityUserDetails member
+    ){
+        return ResponseDto.onSuccess(null);
+    }
+
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -2,9 +2,6 @@ package com.namo.spring.application.external.api.user.controller;
 
 import static com.namo.spring.core.common.code.status.ErrorStatus.*;
 
-import java.awt.print.Pageable;
-import java.util.List;
-
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -52,7 +49,7 @@ public class FriendController {
 
     @Operation(summary = "나에게 온 친구 요청 목록을 조회합니다.", description = "친구 요청 목록 조회 API 입니다. 수락 또는 거절한 친구 요청은 표시되지 않습니다.")
     @GetMapping("/requests")
-    public ResponseDto<FriendshipResponse.GetFriendRequestDto> getFriendRequestList(
+    public ResponseDto<FriendshipResponse.FriendRequestListDto> getFriendRequestList(
             @AuthenticationPrincipal SecurityUserDetails member,
             @Parameter(description = "1 부터 시작하는 페이지 번호입니다 (기본값 1)", example = "1")
             @RequestParam(value = "page", defaultValue = "1") int page
@@ -91,13 +88,16 @@ public class FriendController {
         return ResponseDto.onSuccess("친구 요청을 거절했습니다.");
     }
 
-    @Operation(summary = "내 친구 목록을 조회합니다. [20명씩 조회]", description = "내 친구 리스트를 보는 API 입니다.")
+    @Operation(summary = "내 친구 목록을 조회합니다. [20명씩 조회]", description = "내 친구 리스트를 보는 API 입니다. "
+            + "즐겨찾기에 등록된 친구가 가장 먼저 나오고, 그 후에 최근 추가된 친구들이 조회됩니다. ")
     @GetMapping("")
-    public ResponseDto<FriendshipResponse.GetFriendListDto> getFriendList(
+    public ResponseDto<FriendshipResponse.FriendListDto> getFriendList(
             @AuthenticationPrincipal SecurityUserDetails member,
+            @Parameter(description = "1부터 시작하는 페이지 번호입니다. 20명씩 조회됩니다.", example = "3")
             @RequestParam(defaultValue = "1") int page
     ){
-        return ResponseDto.onSuccess(null);
+        return ResponseDto.onSuccess(friendUseCase
+                .getFriendList(member.getUserId(), page));
     }
 
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -52,7 +52,7 @@ public class FriendController {
 
     @Operation(summary = "나에게 온 친구 요청 목록을 조회합니다.", description = "친구 요청 목록 조회 API 입니다. 수락 또는 거절한 친구 요청은 표시되지 않습니다.")
     @GetMapping("/requests")
-    public ResponseDto<List<FriendshipResponse.FriendRequestDto>> getFriendRequestList(
+    public ResponseDto<FriendshipResponse.GetFriendRequestDto> getFriendRequestList(
             @AuthenticationPrincipal SecurityUserDetails member,
             @Parameter(description = "1 부터 시작하는 페이지 번호입니다 (기본값 1)", example = "1")
             @RequestParam(value = "page", defaultValue = "1") int page

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -2,6 +2,7 @@ package com.namo.spring.application.external.api.user.controller;
 
 import static com.namo.spring.core.common.code.status.ErrorStatus.*;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -90,10 +91,11 @@ public class FriendController {
         return ResponseDto.onSuccess("친구 요청을 거절했습니다.");
     }
 
-    @Operation(summary = "내 친구 목록을 조회합니다.", description = "내 친구 리스트를 보는 API 입니다.")
+    @Operation(summary = "내 친구 목록을 조회합니다. [20명씩 조회]", description = "내 친구 리스트를 보는 API 입니다.")
     @GetMapping("")
-    public ResponseDto<List<FriendshipResponse.FriendInfoDto>> getFriendList(
-            @AuthenticationPrincipal SecurityUserDetails member
+    public ResponseDto<FriendshipResponse.GetFriendListDto> getFriendList(
+            @AuthenticationPrincipal SecurityUserDetails member,
+            @RequestParam(defaultValue = "1") int page
     ){
         return ResponseDto.onSuccess(null);
     }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
@@ -20,11 +20,11 @@ public class FriendshipConverter {
                 .build();
     }
 
-    public static FriendshipResponse.GetFriendRequestDto toGetFriendRequestDto(Page<Friendship> friendships){
+    public static FriendshipResponse.FriendRequestListDto toFriendRequestDto(Page<Friendship> friendships){
         List<FriendshipResponse.FriendRequestDto> friendRequestDto = friendships.stream()
                 .map(FriendshipConverter::toFriendRequestDto)
                 .toList();
-        return FriendshipResponse.GetFriendRequestDto.builder()
+        return FriendshipResponse.FriendRequestListDto.builder()
                 .friendRequests(friendRequestDto)
                 .currentPage(friendships.getNumber()+1)
                 .pageSize(friendships.getSize())
@@ -33,8 +33,9 @@ public class FriendshipConverter {
                 .build();
     }
 
-    public static FriendshipResponse.FriendRequestDto toFriendRequestDto(Friendship friendship){
+    private static FriendshipResponse.FriendRequestDto toFriendRequestDto(Friendship friendship){
         Member requestMember = friendship.getMember();
+        // todo : birthday 로직 일원화 필요 2024.10.23 Castle
         String birthday = requestMember.isBirthdayVisible() ? requestMember.getBirthday().format(DateTimeFormatter.ofPattern("MM-dd")) : BIRTHDAY_HIDDEN;
         return FriendshipResponse.FriendRequestDto.builder()
                 .friendRequestId(friendship.getId())
@@ -45,6 +46,32 @@ public class FriendshipConverter {
                 .bio(requestMember.getBio())
                 .birthday(birthday)
                 .favoriteColorId(requestMember.getPalette().getId())
+                .build();
+    }
+
+    public static FriendshipResponse.FriendListDto toFriendListDto(Page<Friendship> friendships) {
+        List<FriendshipResponse.FriendInfoDto> friendList = friendships.stream()
+                .map(FriendshipConverter::toFriendInfoDto)
+                .toList();
+        return FriendshipResponse.FriendListDto.builder()
+                .friendList(friendList)
+                .currentPage(friendships.getNumber()+1)
+                .pageSize(friendships.getSize())
+                .totalPages(friendships.getTotalPages())
+                .totalItems(friendships.getTotalElements())
+                .build();
+    }
+
+    private static FriendshipResponse.FriendInfoDto toFriendInfoDto(Friendship friendship){
+        Member friend = friendship.getFriend();
+        String birthday = friend.isBirthdayVisible() ? friend.getBirthday().format(DateTimeFormatter.ofPattern("MM-dd")) : BIRTHDAY_HIDDEN;
+        return FriendshipResponse.FriendInfoDto.builder()
+                .memberId(friend.getId())
+                .nickname(friend.getNickname())
+                .tag(friend.getTag())
+                .bio(friend.getBio())
+                .birthday(birthday)
+                .favoriteColorId(friend.getPalette().getId())
                 .build();
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
@@ -4,8 +4,10 @@ import com.namo.spring.application.external.api.user.dto.FriendshipResponse;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
 
 public class FriendshipConverter {
 
@@ -15,6 +17,19 @@ public class FriendshipConverter {
         return Friendship.builder()
                 .member(request)
                 .friend(target)
+                .build();
+    }
+
+    public static FriendshipResponse.GetFriendRequestDto toGetFriendRequestDto(Page<Friendship> friendships){
+        List<FriendshipResponse.FriendRequestDto> friendRequestDto = friendships.stream()
+                .map(FriendshipConverter::toFriendRequestDto)
+                .toList();
+        return FriendshipResponse.GetFriendRequestDto.builder()
+                .friendRequests(friendRequestDto)
+                .currentPage(friendships.getNumber()+1)
+                .pageSize(friendships.getSize())
+                .totalPages(friendships.getTotalPages())
+                .totalItems(friendships.getTotalElements())
                 .build();
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
@@ -11,7 +11,7 @@ public class FriendshipResponse {
 
     @Getter
     @Builder
-    public static class GetFriendRequestDto{
+    public static class FriendRequestListDto {
         List<FriendRequestDto> friendRequests;
         @Schema(description = "총 페이지 수", example = "5")
         private int totalPages;
@@ -46,7 +46,7 @@ public class FriendshipResponse {
 
     @Getter
     @Builder
-    public static class GetFriendListDto{
+    public static class FriendListDto {
         List<FriendInfoDto> friendList;
         @Schema(description = "총 페이지 수", example = "5")
         private int totalPages;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
@@ -1,9 +1,5 @@
 package com.namo.spring.application.external.api.user.dto;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.Builder;
@@ -20,7 +16,7 @@ public class FriendshipResponse {
         private Long friendRequestId;
         @Schema(description = "친구 요청 유저 프로필 이미지", example = "https://static.namong.shop/resized/origin/member/image.png")
         private String profileImage;
-        @Schema(description = "친구 요청 유저 닉네임 ID", example = "2")
+        @Schema(description = "친구 요청 유저 닉네임", example = "캐슬")
         private String nickname;
         @Schema(description = "친구 요청 유저 태그", example = "1234")
         private String tag;
@@ -29,6 +25,23 @@ public class FriendshipResponse {
         @Schema(description = "친구 요청 유저 생일 (비공개 존재)", example = "02-22")
         private String birthday;
         @Schema(description = "친구 요청 유저 선호 색", example = "2")
+        private Long favoriteColorId;
+    }
+
+    @Getter
+    @Builder
+    public static class FriendInfoDto{
+        @Schema(description = "친구 memberID", example = "1")
+        private Long memberId;
+        @Schema(description = "친구 닉네임", example = "캐슬")
+        private String nickname;
+        @Schema(description = "친구 태그", example = "1234")
+        private String tag;
+        @Schema(description = "친구 한줄 소개", example = "3")
+        private String bio;
+        @Schema(description = "친구 생일 (비공개 존재)", example = "02-22")
+        private String birthday;
+        @Schema(description = "친구 선호 색", example = "2")
         private Long favoriteColorId;
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
@@ -1,5 +1,7 @@
 package com.namo.spring.application.external.api.user.dto;
 
+import java.util.List;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.Builder;
@@ -26,6 +28,20 @@ public class FriendshipResponse {
         private String birthday;
         @Schema(description = "친구 요청 유저 선호 색", example = "2")
         private Long favoriteColorId;
+    }
+
+    @Getter
+    @Builder
+    public static class GetFriendListDto{
+        List<FriendInfoDto> friendList;
+        @Schema(description = "총 페이지 수", example = "5")
+        private int totalPages;
+        @Schema(description = "현재 페이지 번호", example = "1")
+        private int currentPage;
+        @Schema(description = "한 페이지당 항목 수", example = "20")
+        private int pageSize;
+        @Schema(description = "전체 항목 수", example = "100")
+        private long totalItems;
     }
 
     @Getter

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
@@ -11,6 +11,20 @@ public class FriendshipResponse {
 
     @Getter
     @Builder
+    public static class GetFriendRequestDto{
+        List<FriendRequestDto> friendRequests;
+        @Schema(description = "총 페이지 수", example = "5")
+        private int totalPages;
+        @Schema(description = "현재 페이지 번호", example = "1")
+        private int currentPage;
+        @Schema(description = "한 페이지당 항목 수", example = "20")
+        private int pageSize;
+        @Schema(description = "전체 항목 수", example = "100")
+        private long totalItems;
+    }
+
+    @Getter
+    @Builder
     public static class FriendRequestDto{
         @Schema(description = "친구 요청 보낸 유저 ID", example = "4")
         private Long memberId;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -107,4 +107,17 @@ public class FriendManageService {
             throw new ScheduleException(ErrorStatus.NOT_FRIENDSHIP_MEMBER);
         }
     }
+
+    /**
+     * 나의 친구 목록을 가져옵니다.
+     * !! 즐겨찾기에 등록된 친구가 가장 먼저 나오고, 그 후에 최근 추가된 친구들이 조회됩니다.
+     * @param memberId
+     * @param page
+     * @return
+     */
+    public Page<Friendship> getAcceptedFriendship(Long memberId, int page) {
+        Pageable pageable = PageRequest.of(page - 1, REQUEST_PAGE_SIZE,
+                Sort.by(Sort.Order.desc("isFavorite"), Sort.Order.desc("createdAt")));
+        return friendshipService.readAllFriendshipByStatus(memberId, FriendshipStatus.ACCEPTED, pageable);
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -5,8 +5,11 @@ import java.util.List;
 
 import com.namo.spring.db.mysql.domains.schedule.exception.ScheduleException;
 import com.namo.spring.db.mysql.domains.user.dto.FriendBirthdayQuery;
+
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.namo.spring.application.external.api.user.converter.FriendshipConverter;
@@ -47,7 +50,7 @@ public class FriendManageService {
      * @param memberId 요청을 받는 사용자의 ID
      * @return PENDING 상태의 친구 요청 목록
      */
-    public List<Friendship> getReceivedFriendRequests(Long memberId, int page) {
+    public Page<Friendship> getReceivedFriendRequests(Long memberId, int page) {
         Pageable pageable = PageRequest.of(page - 1, REQUEST_PAGE_SIZE);
         return friendshipService.readAllFriendshipByStatus(memberId, FriendshipStatus.PENDING, pageable);
     }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -1,7 +1,9 @@
 package com.namo.spring.application.external.api.user.usecase;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,11 +31,9 @@ public class FriendUseCase {
     }
 
     @Transactional(readOnly = true)
-    public List<FriendshipResponse.FriendRequestDto> getFriendshipRequest(Long memberId, int page) {
-        List<Friendship> receivedRequests = friendManageService.getReceivedFriendRequests(memberId, page);
-        return receivedRequests.stream()
-                .map(FriendshipConverter::toFriendRequestDto)
-                .toList();
+    public FriendshipResponse.GetFriendRequestDto getFriendshipRequest(Long memberId, int page) {
+        Page<Friendship> receivedRequests = friendManageService.getReceivedFriendRequests(memberId, page);
+        return FriendshipConverter.toGetFriendRequestDto(receivedRequests);
     }
 
     @Transactional

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -1,8 +1,5 @@
 package com.namo.spring.application.external.api.user.usecase;
 
-import java.awt.print.Pageable;
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,9 +28,9 @@ public class FriendUseCase {
     }
 
     @Transactional(readOnly = true)
-    public FriendshipResponse.GetFriendRequestDto getFriendshipRequest(Long memberId, int page) {
+    public FriendshipResponse.FriendRequestListDto getFriendshipRequest(Long memberId, int page) {
         Page<Friendship> receivedRequests = friendManageService.getReceivedFriendRequests(memberId, page);
-        return FriendshipConverter.toGetFriendRequestDto(receivedRequests);
+        return FriendshipConverter.toFriendRequestDto(receivedRequests);
     }
 
     @Transactional
@@ -46,5 +43,11 @@ public class FriendUseCase {
     public void rejectFriendRequest(Long memberId, Long friendshipId) {
         Friendship friendship = friendManageService.getPendingFriendship(friendshipId);
         friendManageService.rejectRequest(memberId, friendship);
+    }
+
+    @Transactional(readOnly = true)
+    public FriendshipResponse.FriendListDto getFriendList(Long userId, int page) {
+        Page<Friendship> friendships = friendManageService.getAcceptedFriendship(userId, page);
+        return FriendshipConverter.toFriendListDto(friendships);
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import com.namo.spring.db.mysql.domains.user.dto.FriendBirthdayQuery;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,7 +19,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
 
     boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
 
-    List<Friendship> findAllByFriendIdAndStatus(Long memberId, FriendshipStatus status, Pageable pageable);
+    Page<Friendship> findAllByFriendIdAndStatus(Long memberId, FriendshipStatus status, Pageable pageable);
 
     Optional<Friendship> findByIdAndStatus(Long friendshipId, FriendshipStatus status);
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.namo.spring.core.common.annotation.DomainService;
@@ -32,7 +33,7 @@ public class FriendshipService {
         return friendshipRepository.save(friendship);
     }
 
-    public List<Friendship> readAllFriendshipByStatus(Long memberId, FriendshipStatus status, Pageable pageable) {
+    public Page<Friendship> readAllFriendshipByStatus(Long memberId, FriendshipStatus status, Pageable pageable) {
         return friendshipRepository.findAllByFriendIdAndStatus(memberId, status, pageable);
     }
 


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

### 1. 구현사항
- 나의 친구목록을 조회하는 API를 구현했습니다.
  - 즐겨찾기에 등록된 친구가 가장 먼저 나오고, 그 후에 최근 추가된 친구들이 조회됩니다.
  - 20명씩 페이징되며 시작 page는 1번입니다.
  - Page 정보가 함께 return 됩니다.

### 2. 도메인 로직 변경 사항
- 친구상태와 페이징 객체를 사용해 친구 목록을 조회하는 도메인 로직이 기존 List를 반환하던 로직에서 Page를 반환합니다.
  - 사유 : Page 객체를 사용하기 위한 변경

### 3. 클라이언트 변경사항
- 나에게 온 친구 요청 목록을 조회시 Page 정보가 포함되어 return되도록 리팩토링 되었습니다.

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 기존 API 의 변경으로 잘못된 곳은 없는지 확인 부탁드립니다.

## 참고 자료
<img width="243" alt="image" src="https://github.com/user-attachments/assets/3eec1144-2216-4549-9f24-dda989666b36">
<img width="226" alt="image" src="https://github.com/user-attachments/assets/9822946a-935c-4afe-9aad-26bb19817821">



## 관련 이슈

- close #382 
