### PR TITLE
[Feature/384] 친구 즐겨찾기(선호친구) 등록/해제 기능 구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "8. 친구", description = "친구 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/friends")
+@RequestMapping("/api/v2/friends")
 public class FriendController {
 
     private final FriendUseCase friendUseCase;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -2,6 +2,7 @@ package com.namo.spring.application.external.api.user.controller;
 
 import static com.namo.spring.core.common.code.status.ErrorStatus.*;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -100,4 +101,15 @@ public class FriendController {
                 .getFriendList(member.getUserId(), page));
     }
 
+    @Operation(summary = "친구 즐겨찾기 등록/해제", description = "특정 친구를 즐겨찾기에 등록하거나, 이미 등록되어 있다면 해제합니다.")
+    @PatchMapping("/{friendId}/toggle-favorite")
+    @ApiErrorCodes(value = {
+            NOT_FOUND_FRIENDSHIP_FAILURE,
+    })
+    public ResponseDto<String> toggleFavorite(@AuthenticationPrincipal SecurityUserDetails member,
+            @PathVariable Long friendId) {
+        boolean isFavorite = friendUseCase.toggleFavorite(member.getUserId(), friendId);
+        String message = isFavorite ? "친구를 즐겨찾기에 등록했습니다." : "친구를 즐겨찾기에서 해제했습니다.";
+        return ResponseDto.onSuccess(message);
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -94,7 +94,7 @@ public class FriendController {
     @GetMapping("")
     public ResponseDto<FriendshipResponse.FriendListDto> getFriendList(
             @AuthenticationPrincipal SecurityUserDetails member,
-            @Parameter(description = "1부터 시작하는 페이지 번호입니다. 20명씩 조회됩니다.", example = "3")
+            @Parameter(description = "1부터 시작하는 페이지 번호입니다. 20명씩 조회됩니다.", example = "1")
             @RequestParam(defaultValue = "1") int page
     ){
         return ResponseDto.onSuccess(friendUseCase

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -90,7 +90,7 @@ public class FriendController {
     }
 
     @Operation(summary = "내 친구 목록을 조회합니다. [20명씩 조회]", description = "내 친구 리스트를 보는 API 입니다. "
-            + "즐겨찾기에 등록된 친구가 가장 먼저 나오고, 그 후에 최근 추가된 친구들이 조회됩니다. ")
+            + "즐겨찾기에 등록된 친구가 가장 먼저 나오고, 그 후에 닉네임 사전 순으로 정렬됩니다. ")
     @GetMapping("")
     public ResponseDto<FriendshipResponse.FriendListDto> getFriendList(
             @AuthenticationPrincipal SecurityUserDetails member,

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendshipConverter.java
@@ -67,6 +67,7 @@ public class FriendshipConverter {
         String birthday = friend.isBirthdayVisible() ? friend.getBirthday().format(DateTimeFormatter.ofPattern("MM-dd")) : BIRTHDAY_HIDDEN;
         return FriendshipResponse.FriendInfoDto.builder()
                 .memberId(friend.getId())
+                .favoriteFriend(friendship.isFavorite())
                 .nickname(friend.getNickname())
                 .tag(friend.getTag())
                 .bio(friend.getBio())

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendshipResponse.java
@@ -63,6 +63,8 @@ public class FriendshipResponse {
     public static class FriendInfoDto{
         @Schema(description = "친구 memberID", example = "1")
         private Long memberId;
+        @Schema(description = "선호 친구 여부", example = "true or false")
+        private Boolean favoriteFriend;
         @Schema(description = "친구 닉네임", example = "캐슬")
         private String nickname;
         @Schema(description = "친구 태그", example = "1234")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -120,4 +120,9 @@ public class FriendManageService {
                 Sort.by(Sort.Order.desc("isFavorite"), Sort.Order.desc("createdAt")));
         return friendshipService.readAllFriendshipByStatus(memberId, FriendshipStatus.ACCEPTED, pageable);
     }
+
+    public Friendship getAcceptedFriendship(Long memberId, Long friendId){
+        return friendshipService.readFriendshipByStatus(memberId, friendId, FriendshipStatus.ACCEPTED)
+                .orElseThrow(() -> new MemberException(ErrorStatus.NOT_FOUND_FRIENDSHIP_FAILURE));
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -52,7 +52,7 @@ public class FriendManageService {
      */
     public Page<Friendship> getReceivedFriendRequests(Long memberId, int page) {
         Pageable pageable = PageRequest.of(page - 1, REQUEST_PAGE_SIZE);
-        return friendshipService.readAllFriendshipByStatus(memberId, FriendshipStatus.PENDING, pageable);
+        return friendshipService.readAllReceivedFriendshipByStatus(memberId, FriendshipStatus.PENDING, pageable);
     }
 
     /**
@@ -118,7 +118,7 @@ public class FriendManageService {
     public Page<Friendship> getAcceptedFriendship(Long memberId, int page) {
         Pageable pageable = PageRequest.of(page - 1, REQUEST_PAGE_SIZE,
                 Sort.by(Sort.Order.desc("isFavorite"), Sort.Order.desc("createdAt")));
-        return friendshipService.readAllFriendshipByStatus(memberId, FriendshipStatus.ACCEPTED, pageable);
+        return friendshipService.readAllRequestFriendshipByStatus(memberId, FriendshipStatus.ACCEPTED, pageable);
     }
 
     public Friendship getAcceptedFriendship(Long memberId, Long friendId){

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -110,14 +110,14 @@ public class FriendManageService {
 
     /**
      * 나의 친구 목록을 가져옵니다.
-     * !! 즐겨찾기에 등록된 친구가 가장 먼저 나오고, 그 후에 최근 추가된 친구들이 조회됩니다.
+     * !! 즐겨찾기에 등록된 친구가 가장 먼저 나오고, 그 후에 친구 닉네임 사전순으로 조회됩니다.
      * @param memberId
      * @param page
      * @return
      */
     public Page<Friendship> getAcceptedFriendship(Long memberId, int page) {
         Pageable pageable = PageRequest.of(page - 1, REQUEST_PAGE_SIZE,
-                Sort.by(Sort.Order.desc("isFavorite"), Sort.Order.desc("createdAt")));
+                Sort.by(Sort.Order.desc("isFavorite"), Sort.Order.asc("friend.nickname")));
         return friendshipService.readAllRequestFriendshipByStatus(memberId, FriendshipStatus.ACCEPTED, pageable);
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -50,4 +50,10 @@ public class FriendUseCase {
         Page<Friendship> friendships = friendManageService.getAcceptedFriendship(userId, page);
         return FriendshipConverter.toFriendListDto(friendships);
     }
+
+    @Transactional
+    public void toggleFavorite(Long memberId, Long friendId) {
+        Friendship friendship = friendManageService.getAcceptedFriendship(memberId, friendId);
+        friendship.toggleFavorite();
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -52,8 +52,9 @@ public class FriendUseCase {
     }
 
     @Transactional
-    public void toggleFavorite(Long memberId, Long friendId) {
+    public boolean toggleFavorite(Long memberId, Long friendId) {
         Friendship friendship = friendManageService.getAcceptedFriendship(memberId, friendId);
         friendship.toggleFavorite();
+        return friendship.isFavorite();
     }
 }

--- a/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
+++ b/core/core-common/src/main/java/com/namo/spring/core/common/code/status/ErrorStatus.java
@@ -140,7 +140,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
 
-    NOT_FOUND_FRIENDSHIP_FAILURE(HttpStatus.NOT_FOUND, "친구인 유저를 찾을 수 없습니다."),
+    NOT_FOUND_FRIENDSHIP_FAILURE(HttpStatus.NOT_FOUND, "친구인 유저를 찾을 수 없습니다. (대기중인 요청일 수 있습니다)"),
 
     NOT_FOUND_MOBILE_DEVICE_FAILURE(HttpStatus.NOT_FOUND, "유저의 모바일 기기 정보를 찾을 수 없습니다."),
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Friendship.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Friendship.java
@@ -53,12 +53,8 @@ public class Friendship extends BaseTimeEntity {
         this.isFavorite = false;
     }
 
-    public void setFavorite() {
-        this.isFavorite = true;
-    }
-
-    public void setUnFavorite() {
-        this.isFavorite = false;
+    public void toggleFavorite() {
+        this.isFavorite = !isFavorite;
     }
 
     public void accept() {

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
@@ -49,4 +49,5 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
             LocalDate startDate,
             LocalDate endDate);
 
+    Optional<Friendship> findByMemberIdAndFriendIdAndStatus(Long memberId, Long friendId, FriendshipStatus status);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
@@ -50,4 +50,6 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
             LocalDate endDate);
 
     Optional<Friendship> findByMemberIdAndFriendIdAndStatus(Long memberId, Long friendId, FriendshipStatus status);
+
+    Page<Friendship> findAllByMemberIdAndStatus(Long memberId, FriendshipStatus status, Pageable pageable);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import com.namo.spring.db.mysql.domains.user.dto.FriendBirthdayQuery;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.type.FriendshipStatus;
@@ -51,5 +52,8 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
 
     Optional<Friendship> findByMemberIdAndFriendIdAndStatus(Long memberId, Long friendId, FriendshipStatus status);
 
-    Page<Friendship> findAllByMemberIdAndStatus(Long memberId, FriendshipStatus status, Pageable pageable);
+    @Query("SELECT f FROM Friendship f "
+            + "JOIN FETCH f.friend "
+            + "WHERE f.member.id = :memberId AND f.status = :status")
+    Page<Friendship> findAllByMemberIdAndStatusFetchJoin(@Param("memberId") Long memberId, @Param("status") FriendshipStatus status, Pageable pageable);
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -41,6 +41,11 @@ public class FriendshipService {
         return friendshipRepository.findByIdAndStatus(friendshipId, status);
     }
 
+    public Optional<Friendship> readFriendshipByStatus(Long memberId, Long friendId, FriendshipStatus status){
+        return friendshipRepository.findByMemberIdAndFriendIdAndStatus(memberId,friendId, status);
+    }
+
+
     public void delete(Friendship friendship) {
         friendshipRepository.delete(friendship);
     }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -44,7 +44,7 @@ public class FriendshipService {
      * memberId(나)에서 시작한 친구 관계로 탐색
      */
     public Page<Friendship> readAllRequestFriendshipByStatus(Long memberId, FriendshipStatus status, Pageable pageable) {
-        return friendshipRepository.findAllByMemberIdAndStatus(memberId, status, pageable);
+        return friendshipRepository.findAllByMemberIdAndStatusFetchJoin(memberId, status, pageable);
     }
 
     public Optional<Friendship> readFriendshipByStatus(Long friendshipId, FriendshipStatus status){

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -33,8 +33,18 @@ public class FriendshipService {
         return friendshipRepository.save(friendship);
     }
 
-    public Page<Friendship> readAllFriendshipByStatus(Long memberId, FriendshipStatus status, Pageable pageable) {
+    /**
+     * memberId(나)에게 도착한 친구 관계로 탐색
+     */
+    public Page<Friendship> readAllReceivedFriendshipByStatus(Long memberId, FriendshipStatus status, Pageable pageable) {
         return friendshipRepository.findAllByFriendIdAndStatus(memberId, status, pageable);
+    }
+
+    /**
+     * memberId(나)에서 시작한 친구 관계로 탐색
+     */
+    public Page<Friendship> readAllRequestFriendshipByStatus(Long memberId, FriendshipStatus status, Pageable pageable) {
+        return friendshipRepository.findAllByMemberIdAndStatus(memberId, status, pageable);
     }
 
     public Optional<Friendship> readFriendshipByStatus(Long friendshipId, FriendshipStatus status){


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [X] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

### 구현 사항
- 친구 즐겨 찾기 등록/해제 기능을 구현했습니다.
  - 토글(Toggle) 방식으로 구현하여 현재 상태에 기반하여 등록/해제 됩니다.

### 리팩토링 사항
- 기존 메서드 이름에 수신 발신 친구 조회 구분이 없어 리스트 조회건에 대해 구분했습니다.
- 친구 리스트 조회시 N+1 문제를 방지하고 속도를 개선하기 위해 리스트 조회시 Fetch Join을 통해 친구정보를 로딩합니다.

### 클라이언트 수정사항
- 친구 리스트 조회시 선호 컬럼이 빠져 추가되었습니다.
- 친구 리스트 정렬 방식이 즐겨찾기 + 최신순 -> 즐겨찾기 + 닉네임 사전순으로 변경되었습니다.


## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-



## 첨부 자료

<img width="269" alt="image" src="https://github.com/user-attachments/assets/d4162b04-171c-488d-b602-f1724bf9bf41">


## 관련 이슈

- close #384 
