### PR TITLE
[Refactor/394] 기록을 스케줄 타입별로 분리하여 Return

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/DiaryResponseConverter.java
@@ -1,7 +1,9 @@
 package com.namo.spring.application.external.api.record.converter;
 
 import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.namo.spring.application.external.api.record.dto.DiaryResponse;
@@ -10,6 +12,7 @@ import com.namo.spring.db.mysql.domains.record.entity.Diary;
 import com.namo.spring.db.mysql.domains.record.entity.DiaryImage;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
+import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
 
 public class DiaryResponseConverter {
 
@@ -69,19 +72,22 @@ public class DiaryResponseConverter {
                 .build();
     }
 
-    public static DiaryResponse.DiaryExistDateDto toDiaryExistDateDto(List<Participant> participants,
-            YearMonth yearMonth) {
+    public static DiaryResponse.DiaryExistDateDto toDiaryExistDateDto(List<Participant> participants, YearMonth yearMonth) {
+        List<Integer> diaryForPersonal = new ArrayList<>();
+        List<Integer> diaryForMeeting = new ArrayList<>();
+        participants.forEach(participant -> {
+            int dayOfMonth = participant.getSchedule().getStartDayOfMonth();
+            if (participant.getSchedule().getScheduleType() ==  ScheduleType.PERSONAL.getValue()) {
+                diaryForPersonal.add(dayOfMonth);
+            } else if (participant.getSchedule().getScheduleType() == ScheduleType.MEETING.getValue()) {
+                diaryForMeeting.add(dayOfMonth);
+            }
+        });
         return DiaryResponse.DiaryExistDateDto.builder()
                 .year(yearMonth.getYear())
                 .month(yearMonth.getMonth().getValue())
-                .dates(participants.stream()
-                        .map(participant -> participant.getSchedule()
-                                .getPeriod()
-                                .getStartDate()
-                                .getDayOfMonth()) // 날짜만 추출
-                        .distinct() // 중복 제거 (만약 중복된 날짜가 있을 경우)
-                        .sorted()
-                        .collect(Collectors.toList()))
+                .DiaryDateForPersonal(diaryForPersonal.stream().distinct().sorted().collect(Collectors.toList()))
+                .DiaryDateForMeeting(diaryForMeeting.stream().distinct().sorted().collect(Collectors.toList()))
                 .build();
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -90,6 +90,8 @@ public class DiaryResponse {
         private List<Integer> DiaryDateForPersonal;
         @Schema(description = "모임 스케줄에 대한 일기가 존재하는 날짜", example = "2, 3, 6")
         private List<Integer> DiaryDateForMeeting;
+        @Schema(description = "생일 스케줄에 대한 일기가 존재하는 날짜", example = "22")
+        private List<Integer> DiaryDateForBirthday;
     }
 
     @Builder

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/DiaryResponse.java
@@ -86,8 +86,10 @@ public class DiaryResponse {
     public static class DiaryExistDateDto {
         private int year;
         private int month;
-        @Schema(description = "일기가 존재하는 날짜", example = "1, 2, 3")
-        private List<Integer> dates;
+        @Schema(description = "개인 스케줄에 대한 일기가 존재하는 날짜", example = "1, 2, 3")
+        private List<Integer> DiaryDateForPersonal;
+        @Schema(description = "모임 스케줄에 대한 일기가 존재하는 날짜", example = "2, 3, 6")
+        private List<Integer> DiaryDateForMeeting;
     }
 
     @Builder

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
@@ -166,4 +166,8 @@ public class Schedule extends BaseTimeEntity {
     public boolean getIsMeetingSchedule() {
         return this.scheduleType == ScheduleType.MEETING.getValue();
     }
+
+    public int getStartDayOfMonth() {
+        return this.getPeriod().getStartDate().getDayOfMonth();
+    }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/entity/Schedule.java
@@ -167,6 +167,14 @@ public class Schedule extends BaseTimeEntity {
         return this.scheduleType == ScheduleType.MEETING.getValue();
     }
 
+    public boolean getIsPersonalSchedule(){
+        return this.scheduleType == ScheduleType.PERSONAL.getValue();
+    }
+
+    public boolean getIsBirthdaySchedule(){
+        return this.scheduleType == ScheduleType.BIRTHDAY.getValue();
+    }
+
     public int getStartDayOfMonth() {
         return this.getPeriod().getStartDate().getDayOfMonth();
     }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

### 변경 사항 
- 월별로 일기 존재날짜 조회하는 API 변경 (기록을 스케줄 타입별로 분리하여 Return)
  - 개인 스케줄에 대한 일기 날짜
  - 모임 스케줄에 대한 일기 날짜
  - 생일 스케줄에 대한 일기 날짜

- 스케줄 도메인에 어떤 타입의 스케줄인지 반환하는 도메인 로직 구현
- 스케줄 시작날짜 가져오는 도메인 로직 구현

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- EnumMap(enum 타입을 키(key)로 사용하는 Map)
장점 : 타입 안정성, NULL 불가능, 순서 보장

나모 기록 날짜의 순서가 중요하고 타입별로 안정성이 보장되어야 하기에 해당 부분에서 처리를 할 수 있는 EnumMap을 사용하여 리팩토링 하였습니다.

### 고민 중인 사항

- 

## 첨부 자료

<img width="260" alt="image" src="https://github.com/user-attachments/assets/fdc1b7a0-3b07-4055-8c23-6350053a1fbe">


## 관련 이슈

- close #394 
