### PR TITLE
[Feature/346] member 테이블에 회원가입 완료일 컬럼 추가

### DIFF
--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
@@ -108,6 +108,8 @@ public class Member extends BaseTimeEntity implements User {
     @JoinColumn(name = "palette_id")
     private Palette palette;
 
+    @Column(name = "sign_up_at")
+    private LocalDateTime signUpAt;
 
     @Column(nullable = false)
     private boolean notificationEnabled;
@@ -180,6 +182,7 @@ public class Member extends BaseTimeEntity implements User {
         this.palette = palette;
         this.status = MemberStatus.ACTIVE;
         this.profileImage = profileImage;
+        this.signUpAt = LocalDateTime.now();
     }
 
     public void updatePalette(Palette palette){

--- a/storage/db-mysql-v2/src/main/resources/db/migration/dev/V1.1.5__Add_signupat_column_to_member_table.sql
+++ b/storage/db-mysql-v2/src/main/resources/db/migration/dev/V1.1.5__Add_signupat_column_to_member_table.sql
@@ -1,0 +1,9 @@
+-- V1.1.5__Add_signupat_column_to_member_table
+
+-- 1. signUpAt 컬럼 추가
+ALTER TABLE member
+    ADD COLUMN sign_up_at DATETIME NULL;
+
+-- 2. createdAt 값을 signUpAt에 복사
+UPDATE member
+SET sign_up_at = created_at;


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 생일 일정 중복 생성 및 마이데이터용 회원가입 완료일 컬럼을 추가하였습니다.
  - 현재 생일 일정 생성 로직 -> 회원 가입 완료와 동시에 올해와 내년의 생일 생성
  - 이후는 매월 1일에 다음해 다음해의 생일 자동 생성 ex) 2024년 10월 1일에 2025년 11월의 생일 생성
  - 예외적으로 중복되는 생일 일정 생성 방지를 위해 회원가입 완료일 컬럼을 추가합니다.


## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-

## 관련 이슈

- close #346
