### PR TITLE
[Feature/397] 친구의 카테고리 정보를 조회하는 API 구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -2,6 +2,8 @@ package com.namo.spring.application.external.api.user.controller;
 
 import static com.namo.spring.core.common.code.status.ErrorStatus.*;
 
+import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.namo.spring.application.external.api.user.dto.FriendCategoryResponse;
 import com.namo.spring.application.external.api.user.dto.FriendshipResponse;
 import com.namo.spring.application.external.api.user.usecase.FriendUseCase;
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
@@ -128,5 +131,14 @@ public class FriendController {
     ){
         friendUseCase.deleteFriend(member.getUserId(), friendId);
         return ResponseDto.onSuccess("친구 삭제 완료");
+    }
+
+    @GetMapping("/{friendId}/categories")
+    public ResponseDto<List<FriendCategoryResponse.CategoryInfoDto>> getFriendCategories(
+            @AuthenticationPrincipal SecurityUserDetails member,
+            @Parameter(description = "카테고리를 조회 할 친구의 memberId를 입력해주세요", example = "1")
+            @PathVariable Long friendId
+    ){
+        return ResponseDto.onSuccess(null);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -133,12 +133,14 @@ public class FriendController {
         return ResponseDto.onSuccess("친구 삭제 완료");
     }
 
+    @Operation(summary = "친구의 스케줄 카테고리 정보를 조회", description = "친구가 등록한 카테고리를 조회합니다(공개된 카테고리만 조회됩니다)")
     @GetMapping("/{friendId}/categories")
     public ResponseDto<List<FriendCategoryResponse.CategoryInfoDto>> getFriendCategories(
             @AuthenticationPrincipal SecurityUserDetails member,
             @Parameter(description = "카테고리를 조회 할 친구의 memberId를 입력해주세요", example = "1")
             @PathVariable Long friendId
     ){
-        return ResponseDto.onSuccess(null);
+        return ResponseDto.onSuccess(friendUseCase
+                .getFriendCategories(member.getUserId(), friendId));
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/FriendController.java
@@ -92,9 +92,10 @@ public class FriendController {
         return ResponseDto.onSuccess("친구 요청을 거절했습니다.");
     }
 
-    @Operation(summary = "내 친구 목록을 조회합니다. [20명씩 조회]", description = "내 친구 리스트를 보는 API 입니다. "
-            + "즐겨찾기에 등록된 친구가 가장 먼저 나오고, 그 후에 닉네임 사전 순으로 정렬됩니다. "
-            + "검색 조건이 있는경우 search에 넣어 주세요 아닌경우 사용하지 않으셔도 됩니다.")
+    @Operation(summary = "내 친구 목록을 조회합니다. [20명씩 조회]", description = """
+            내 친구 리스트를 보는 API 입니다.\s
+            즐겨찾기에 등록된 친구가 가장 먼저 나오고, 그 후에 닉네임 사전 순으로 정렬됩니다.\s
+            검색 조건이 있는경우 search에 넣어 주세요 아닌경우 사용하지 않으셔도 됩니다.""")
     @GetMapping("")
     public ResponseDto<FriendshipResponse.FriendListDto> getFriendList(
             @AuthenticationPrincipal SecurityUserDetails member,
@@ -133,7 +134,10 @@ public class FriendController {
         return ResponseDto.onSuccess("친구 삭제 완료");
     }
 
-    @Operation(summary = "친구의 스케줄 카테고리 정보를 조회", description = "친구가 등록한 카테고리를 조회합니다(공개된 카테고리만 조회됩니다)")
+    @Operation(summary = "친구의 스케줄 카테고리 정보를 조회", description = "친구가 등록한 카테고리를 조회합니다(공개된 카테고리만 조회됩니다) \n 친구가 아닌경우 조회할 수 없습니다.")
+    @ApiErrorCodes(value = {
+            NOT_FOUND_FRIENDSHIP_FAILURE,
+    })
     @GetMapping("/{friendId}/categories")
     public ResponseDto<List<FriendCategoryResponse.CategoryInfoDto>> getFriendCategories(
             @AuthenticationPrincipal SecurityUserDetails member,

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendCategoryConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/FriendCategoryConverter.java
@@ -1,0 +1,17 @@
+package com.namo.spring.application.external.api.user.converter;
+
+import com.namo.spring.application.external.api.user.dto.FriendCategoryResponse;
+import com.namo.spring.db.mysql.domains.category.entity.Category;
+
+public class FriendCategoryConverter {
+
+    public static FriendCategoryResponse.CategoryInfoDto toCategoryInfoDto(Category category){
+        if (!category.isShared()){
+            return null;
+        }
+        return FriendCategoryResponse.CategoryInfoDto.builder()
+                .categoryName(category.getName())
+                .colorId(category.getPalette().getId())
+                .build();
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendCategoryResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/FriendCategoryResponse.java
@@ -1,0 +1,14 @@
+package com.namo.spring.application.external.api.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FriendCategoryResponse {
+
+    @Getter
+    @Builder
+    public static class CategoryInfoDto{
+        private Long colorId;
+        private String categoryName;
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/FriendUseCase.java
@@ -1,13 +1,18 @@
 package com.namo.spring.application.external.api.user.usecase;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.namo.spring.application.external.api.user.converter.FriendCategoryConverter;
 import com.namo.spring.application.external.api.user.converter.FriendshipConverter;
+import com.namo.spring.application.external.api.user.dto.FriendCategoryResponse;
 import com.namo.spring.application.external.api.user.dto.FriendshipResponse;
 import com.namo.spring.application.external.api.user.service.FriendManageService;
 import com.namo.spring.application.external.api.user.service.MemberManageService;
+import com.namo.spring.db.mysql.domains.category.entity.Category;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 
@@ -63,5 +68,15 @@ public class FriendUseCase {
         Friendship target = friendManageService.getAcceptedFriendship(memberId, friendId);
         Friendship reversedTarget = friendManageService.getAcceptedFriendship(friendId, memberId);
         friendManageService.deleteFriendShip(target, reversedTarget);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FriendCategoryResponse.CategoryInfoDto> getFriendCategories(Long memberId, Long friendId) {
+        Friendship friendship = friendManageService.getAcceptedFriendship(memberId, friendId);
+        List<Category> friendCategories = friendship.getFriend().getCategories();
+
+        return friendCategories.stream()
+                .map(FriendCategoryConverter::toCategoryInfoDto)
+                .toList();
     }
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 친구의 카테고리를 조회하는 API를 구현했습니다.
  - 친구 관계에 있는 사람만 조회 가능합니다.
  - 공개된 카테고리 정보만 조회됩니다.

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


### 고민 했던 사항

- 친구 카테고리 dto에 대한 Converter이기 때문에 해당 컨버터에서 공유 여부를 검증하도록 구현했습니다.
  - 이를 통해 일관된 변환 로직으로 CategoryInfoDto를 만들 때 공유 여부가 필수임을 검증했습니다.

## 첨부 자료

<img width="287" alt="image" src="https://github.com/user-attachments/assets/5ebcf767-5321-472e-ab74-7400102741b5">


## 관련 이슈

- close #397 
