### PR TITLE
[Feature/404] S3 멀티파트 업로드를 위한 Presigned URL 생성 및 완료 요청 API 구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/controller/S3Controller.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/controller/S3Controller.java
@@ -72,7 +72,8 @@ public class S3Controller {
     @Operation(
             summary = "S3 멀티파트 업로드 완료 요청",
             description = "이 API는 S3에 멀티파트 업로드를 완료하는 요청을 보냅니다. 클라이언트는 모든 파트를 Presigned URLs을 통해 업로드한 후 이 API를 호출하여 업로드를 최종 완료해야 합니다. \n"
-                    + "업로드가 완료되지 않으면 임시 저장된 파일이 일정 기간(7일) 후 삭제될 수 있습니다."
+                    + "업로드가 완료되지 않으면 임시 저장된 파일이 일정 기간(7일) 후 삭제될 수 있습니다. "
+                    + "partETags example  입니다 : \"[{\\\"partNumber\\\": 1, \\\"eTag\\\": \\\"etag_value_1\\\"}, {\\\"partNumber\\\": 2, \\\"eTag\\\": \\\"etag_value_2\\\"}]\")"
     )
     public ResponseDto<String> complete(
             @Parameter(description = "업로드 완료를 위한 요청 정보를 JSON 형식으로 전달합니다. 이 정보에는 파일 이름, 업로드 ID, 각 파트의 ETag 정보가 포함되어야 합니다.")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/controller/S3Controller.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/controller/S3Controller.java
@@ -78,10 +78,6 @@ public class S3Controller {
             @Parameter(description = "업로드 완료를 위한 요청 정보를 JSON 형식으로 전달합니다. 이 정보에는 파일 이름, 업로드 ID, 각 파트의 ETag 정보가 포함되어야 합니다.")
             @RequestBody MultipartCompleteRequest request
     ) {
-        return ResponseDto.onSuccess(s3Service.completeMultipartUpload(
-                request.getFileName(),
-                request.getUploadId(),
-                request.getPartETags()
-        ));
+        return ResponseDto.onSuccess(s3Service.completeMultipartUpload(request));
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/controller/S3Controller.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/controller/S3Controller.java
@@ -7,12 +7,14 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
 import com.namo.spring.core.common.response.ResponseDto;
+import com.namo.spring.core.infra.common.aws.dto.MultipartCompleteRequest;
 import com.namo.spring.core.infra.common.aws.dto.MultipartStartResponse;
 import com.namo.spring.core.infra.common.aws.s3.S3Uploader;
 
@@ -38,21 +40,48 @@ public class S3Controller {
             INTERNET_SERVER_ERROR})
     @GetMapping("/generate-presigned-url")
     public ResponseDto<String> generatePresignedUrl(
-            @Parameter(description = "이미지 종류입니다 {activity: 활동 이미지, diary: 일기 이미지, cover: 커버 이미지, profile: 프로필 이미지} 입력 가능합니다.", example = "activity")
+            @Parameter(description = "업로드할 이미지의 종류를 선택해 주세요. 예: 'activity' (활동 이미지), 'diary' (일기 이미지), 'cover' (커버 이미지), 'profile' (프로필 이미지)",
+                    example = "activity")
             @RequestParam String prefix,
+            @Parameter(description = "업로드할 파일의 이름을 입력해 주세요.", example = "example.jpg")
             @RequestParam String fileName) {
         String preSignedUrl = s3Service.getPreSignedUrl(prefix, fileName);
         return ResponseDto.onSuccess(preSignedUrl);
     }
 
     @PostMapping("/pre-signed/start")
+    @Operation(
+            summary = "S3 Presigned URLs 생성 요청 (Part 업로드용)",
+            description = "이 API는 클라이언트가 큰 파일을 여러 파트로 나누어 S3에 업로드할 수 있도록 각 파트에 대한 Presigned URL을 생성합니다. \n"
+                    + "파일을 원하는 만큼의 파트로 나누기 위해 partCount에 파트 수를 입력해 주세요. 반환된 각 URL을 사용해 각 파트를 업로드한 후, "
+                    + "업로드가 완료되면 반드시 '/pre-signed/complete' API를 호출하여 최종 업로드를 완료해야 합니다. 그렇지 않으면 S3에 임시로 저장된 파일이 일정 기간(7일) 후 삭제될 수 있습니다."
+    )
     public ResponseDto<MultipartStartResponse> start(
+            @Parameter(description = "업로드할 파일의 이름을 입력해 주세요.", example = "example.jpg")
             @RequestParam String fileName,
-            @Parameter(description = "이미지 종류입니다 {activity: 활동 이미지, diary: 일기 이미지, cover: 커버 이미지, profile: 프로필 이미지} 입력 가능합니다.", example = "activity")
+            @Parameter(description = "업로드할 이미지의 종류를 선택해 주세요. 예: 'activity' (활동 이미지), 'diary' (일기 이미지), 'cover' (커버 이미지), 'profile' (프로필 이미지)",
+                    example = "activity")
             @RequestParam String prefix,
+            @Parameter(description = "파일을 몇 개의 파트로 나누어 업로드할지 입력해 주세요.", example = "3")
             @RequestParam int partCount
     ) {
         return ResponseDto.onSuccess(s3Service.getPreSignedUrls(prefix, fileName, partCount));
     }
 
+    @PostMapping("/pre-signed/complete")
+    @Operation(
+            summary = "S3 멀티파트 업로드 완료 요청",
+            description = "이 API는 S3에 멀티파트 업로드를 완료하는 요청을 보냅니다. 클라이언트는 모든 파트를 Presigned URLs을 통해 업로드한 후 이 API를 호출하여 업로드를 최종 완료해야 합니다. \n"
+                    + "업로드가 완료되지 않으면 임시 저장된 파일이 일정 기간(7일) 후 삭제될 수 있습니다."
+    )
+    public ResponseDto<String> complete(
+            @Parameter(description = "업로드 완료를 위한 요청 정보를 JSON 형식으로 전달합니다. 이 정보에는 파일 이름, 업로드 ID, 각 파트의 ETag 정보가 포함되어야 합니다.")
+            @RequestBody MultipartCompleteRequest request
+    ) {
+        return ResponseDto.onSuccess(s3Service.completeMultipartUpload(
+                request.getFileName(),
+                request.getUploadId(),
+                request.getPartETags()
+        ));
+    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/controller/S3Controller.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/controller/S3Controller.java
@@ -2,13 +2,18 @@ package com.namo.spring.application.external.api.image.controller;
 
 import static com.namo.spring.core.common.code.status.ErrorStatus.*;
 
+import java.net.URL;
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.namo.spring.application.external.global.annotation.swagger.ApiErrorCodes;
 import com.namo.spring.core.common.response.ResponseDto;
+import com.namo.spring.core.infra.common.aws.dto.MultipartStartResponse;
 import com.namo.spring.core.infra.common.aws.s3.S3Uploader;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,4 +44,15 @@ public class S3Controller {
         String preSignedUrl = s3Service.getPreSignedUrl(prefix, fileName);
         return ResponseDto.onSuccess(preSignedUrl);
     }
+
+    @PostMapping("/pre-signed/start")
+    public ResponseDto<MultipartStartResponse> start(
+            @RequestParam String fileName,
+            @Parameter(description = "이미지 종류입니다 {activity: 활동 이미지, diary: 일기 이미지, cover: 커버 이미지, profile: 프로필 이미지} 입력 가능합니다.", example = "activity")
+            @RequestParam String prefix,
+            @RequestParam int partCount
+    ) {
+        return ResponseDto.onSuccess(s3Service.getPreSignedUrls(prefix, fileName, partCount));
+    }
+
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/dto/MultipartStartResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/dto/MultipartStartResponse.java
@@ -1,0 +1,17 @@
+package com.namo.spring.application.external.api.image.dto;
+
+import java.net.URL;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MultipartStartResponse {
+    private String uploadId;
+    private List<URL> presignedUrls;
+    private String fileName;
+}

--- a/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/dto/MultipartCompleteRequest.java
+++ b/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/dto/MultipartCompleteRequest.java
@@ -1,0 +1,16 @@
+package com.namo.spring.core.infra.common.aws.dto;
+
+import java.util.List;
+
+import com.amazonaws.services.s3.model.PartETag;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MultipartCompleteRequest {
+    private String fileName;
+    private String uploadId;
+    private List<PartETag> partETags;
+}

--- a/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/dto/MultipartStartResponse.java
+++ b/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/dto/MultipartStartResponse.java
@@ -1,4 +1,4 @@
-package com.namo.spring.application.external.api.image.dto;
+package com.namo.spring.core.infra.common.aws.dto;
 
 import java.net.URL;
 import java.util.List;

--- a/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/s3/S3Uploader.java
+++ b/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/s3/S3Uploader.java
@@ -2,7 +2,6 @@ package com.namo.spring.core.infra.common.aws.s3;
 
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -15,11 +14,13 @@ import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.namo.spring.core.infra.common.aws.dto.MultipartStartResponse;
 import com.namo.spring.core.infra.common.constant.FilePath;
@@ -171,6 +172,28 @@ public class S3Uploader {
         String filepath = FilePath.getPathForPrefix(prefix);
 
         return String.format("%s/%s", filepath, fileId + fileName);
+    }
+
+    /**
+     * part 업로드 완료 처리 (합침, 태깅으로 삭제 방지)
+     * @param fileName
+     * @param uploadId
+     * @param partETags
+     * @return
+     */
+    public String completeMultipartUpload(
+            String fileName,
+            String uploadId,
+            List<PartETag> partETags
+    ) {
+        CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+                awsS3Config.getBucketName(),
+                fileName,
+                uploadId,
+                partETags
+        );
+
+        return amazonS3Client.completeMultipartUpload(completeRequest).getLocation();
     }
 }
 

--- a/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/s3/S3Uploader.java
+++ b/core/core-infra/src/main/java/com/namo/spring/core/infra/common/aws/s3/S3Uploader.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.namo.spring.core.infra.common.aws.dto.MultipartCompleteRequest;
 import com.namo.spring.core.infra.common.aws.dto.MultipartStartResponse;
 import com.namo.spring.core.infra.common.constant.FilePath;
 import com.namo.spring.core.infra.config.AwsS3Config;
@@ -176,21 +177,14 @@ public class S3Uploader {
 
     /**
      * part 업로드 완료 처리 (합침, 태깅으로 삭제 방지)
-     * @param fileName
-     * @param uploadId
-     * @param partETags
      * @return
      */
-    public String completeMultipartUpload(
-            String fileName,
-            String uploadId,
-            List<PartETag> partETags
-    ) {
+    public String completeMultipartUpload(MultipartCompleteRequest request) {
         CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
                 awsS3Config.getBucketName(),
-                fileName,
-                uploadId,
-                partETags
+                request.getFileName(),
+                request.getUploadId(),
+                request.getPartETags()
         );
 
         return amazonS3Client.completeMultipartUpload(completeRequest).getLocation();


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- /pre-signed/start 엔드포인트: S3 멀티파트 업로드를 시작하기 위한 Presigned URL을 생성하여 각 파트를 나누어 업로드할 수 있도록 합니다.
  - 클라이언트는 원하는 파트 수 (partCount)를 입력하여, 해당 수만큼의 Presigned URL 리스트를 반환받습니다.
  - 반환된 URL을 통해 각 파트를 S3에 업로드한 후, 모든 파트를 업로드한 뒤 /pre-signed/complete 엔드포인트를 통해 업로드 완료 요청을 해야 합니다.
- /pre-signed/complete 엔드포인트: 멀티파트 업로드의 최종 완료 요청을 처리하는 API입니다.
  - 모든 파트 업로드가 완료된 후, 각 파트의 partNumber와 eTag 정보가 포함된 partETags를 함께 전달해야 합니다.
  - 업로드 완료 요청을 통해 S3에 최종적으로 파일이 저장되며, 완료 요청이 없을 경우 임시로 저장된 파일이 7일 후 자동으로 삭제됩니다.

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

### 기능 설명

멀티파트 업로드의 Presigned URL 생성 (/pre-signed/start)

- 클라이언트는 이 API를 호출하여 파일을 여러 파트로 나누어 업로드할 수 있는 Presigned URL 리스트를 생성받습니다.
- partCount를 입력하여 원하는 파트 수만큼 URL을 생성할 수 있으며, 각 URL은 개별 파트 업로드에 사용됩니다.
- 클라이언트가 파일의 파트를 S3에 업로드한 후, 업로드 완료를 위해 반드시 /pre-signed/complete API를 호출해야 합니다.

멀티파트 업로드 완료 (/pre-signed/complete)
- 모든 파트를 업로드한 후 각 파트의 partNumber와 eTag 정보가 포함된 partETags 리스트를 전달하여 최종 업로드를 완료할 수 있습니다.
- partETags 예제는 Swagger 주석에 포함되어 있으며, JSON 형식으로 각 파트에 대한 partNumber와 eTag를 전달해야 합니다.
  - eTag 는 PUT으로 이미지를 업로드 한 이후 헤더에 "ETag"라는 Key 값으로 반환됩니다.
- 업로드 완료 요청을 하지 않으면, S3에 임시로 저장된 파일이 7일 후 자동으로 삭제됩니다.

## 첨부 자료

- presingedURL PUT 요청 응답 헤더
<img width="638" alt="image" src="https://github.com/user-attachments/assets/d98cbf19-8384-4ad1-961e-50626e1ef598">
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/7704f92b-cece-42e0-93ed-263e11217406">


## 관련 이슈

- close #404 
