### PR TITLE
[Feature/413] "모임 활동 조회" API 캐시 적용

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/NamoApplication.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/NamoApplication.java
@@ -3,7 +3,9 @@ package com.namo.spring;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class NamoApplication {

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/ActivityController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/Controller/ActivityController.java
@@ -43,7 +43,7 @@ public class ActivityController {
             NOT_FOUND_SCHEDULE_FAILURE,
     })
     @GetMapping("/{scheduleId}")
-    public ResponseDto<List<ActivityResponse.ActivityInfoDto>> getActivity(
+    public ResponseDto<ActivityResponse.ActivityInfoDtoList> getActivity(
             @AuthenticationPrincipal SecurityUserDetails memberInfo,
             @Parameter(description = "활동을 조회할 스케줄 ID 입니다..", example = "1")
             @PathVariable Long scheduleId) {

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/ActivityResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/converter/ActivityResponseConverter.java
@@ -2,6 +2,7 @@ package com.namo.spring.application.external.api.record.converter;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import com.namo.spring.application.external.api.record.dto.ActivityResponse;
@@ -11,6 +12,16 @@ import com.namo.spring.db.mysql.domains.record.entity.ActivityParticipant;
 import com.namo.spring.db.mysql.domains.schedule.type.Location;
 
 public class ActivityResponseConverter {
+
+    public static ActivityResponse.ActivityInfoDtoList toActivityInfoDtoList(List<Activity> activity){
+        List<ActivityResponse.ActivityInfoDto> list = activity.stream()
+                .map(ActivityResponseConverter::toActivityInfoDto)
+                .toList();
+
+        return ActivityResponse.ActivityInfoDtoList.builder()
+                .activityInfoDto(list)
+                .build();
+    }
 
     public static ActivityResponse.ActivityInfoDto toActivityInfoDto(Activity activity) {
         return ActivityResponse.ActivityInfoDto.builder()

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/ActivityResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/ActivityResponse.java
@@ -4,23 +4,44 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class ActivityResponse {
 
     @Builder
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ActivityInfoDtoList{
+        private List<ActivityInfoDto> activityInfoDto;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
     @Schema(description = "활동 조회 DTO")
     public static class ActivityInfoDto {
         private Long activityId;
         private String activityTitle;
         private List<ActivityParticipantDto> activityParticipants;
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm")
         private LocalDateTime activityStartDate;
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm")
         private LocalDateTime activityEndDate;
         private ActivityLocationDto activityLocation;
         private BigDecimal totalAmount;
@@ -31,6 +52,7 @@ public class ActivityResponse {
     @Builder
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     @Schema(description = "활동 참여자 DTO")
     public static class ActivityParticipantDto {
         private Long participantId;
@@ -41,6 +63,7 @@ public class ActivityResponse {
     @Builder
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     @Schema(description = "활동 장소 DTO")
     public static class ActivityLocationDto {
         @Schema(description = "카카오맵 좌표계 상의 x 좌표")
@@ -76,6 +99,7 @@ public class ActivityResponse {
     @Builder
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     @Schema(description = "활동 이미지 정보 DTO")
     public static class ActivityImageDto {
         @Schema(description = "정렬 순서", example = "1")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
@@ -1,7 +1,6 @@
 package com.namo.spring.application.external.api.record.serivce;
 
-import java.util.List;
-
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -15,7 +14,6 @@ import com.namo.spring.db.mysql.domains.record.entity.Activity;
 import com.namo.spring.db.mysql.domains.record.exception.ActivityException;
 import com.namo.spring.db.mysql.domains.record.service.ActivityService;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
-import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.type.Location;
 
 import lombok.RequiredArgsConstructor;
@@ -70,11 +68,15 @@ public class ActivityManageService {
     /**
      * 활동을 업데이트 하는 메서드입니다.
      * 활동 제목, 시작-종료시간, 장소, 이미지를 업데이트 합니다.
+     * 캐시를 무효화 합니다.
      * !! 이미지 업데이트 책임은 activityImageManageService 에 있습니다.
+     *
      * @param activity
      * @param request
+     * @param scheduleId
      */
-    public void updateActivity(Activity activity, ActivityRequest.UpdateActivityDto request) {
+    @CacheEvict(value = "ActivityInfoDtoList", key = "#scheduleId")
+    public void updateActivity(Activity activity, ActivityRequest.UpdateActivityDto request, Long scheduleId) {
         activity.updateInfo(request.getTitle(), request.getActivityStartDate(), request.getActivityEndDate());
         Location newLocation = ActivityConverter.toLocation(request.getLocation());
         activity.updateLocation(newLocation);

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
@@ -87,9 +87,4 @@ public class ActivityManageService {
         activityImageManageService.deleteImages(activity);
         activityService.deleteActivity(activity);
     }
-
-    @Cacheable(value = "activities", key = "#schedule.getId()", unless = "#result==null || #result.isEmpty()")
-    public List<Activity> getCachedActivities(Schedule schedule) {
-        return schedule.getActivityList();
-    }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
@@ -1,7 +1,6 @@
 package com.namo.spring.application.external.api.record.serivce;
 
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
@@ -83,7 +82,8 @@ public class ActivityManageService {
         activityImageManageService.updateImages(activity, request);
     }
 
-    public void removeActivity(Activity activity) {
+    @CacheEvict(value = "ActivityInfoDtoList", key = "#scheduleId")
+    public void removeActivity(Activity activity, Long scheduleId) {
         activity.getActivityImages().forEach(activityImage ->
                 activityImageManageService.deleteFromCloud(activityImage.getId()));
         activityImageManageService.deleteImages(activity);

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
@@ -1,5 +1,8 @@
 package com.namo.spring.application.external.api.record.serivce;
 
+import java.util.List;
+
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
@@ -12,6 +15,7 @@ import com.namo.spring.db.mysql.domains.record.entity.Activity;
 import com.namo.spring.db.mysql.domains.record.exception.ActivityException;
 import com.namo.spring.db.mysql.domains.record.service.ActivityService;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
+import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.type.Location;
 
 import lombok.RequiredArgsConstructor;
@@ -82,5 +86,10 @@ public class ActivityManageService {
                 activityImageManageService.deleteFromCloud(activityImage.getId()));
         activityImageManageService.deleteImages(activity);
         activityService.deleteActivity(activity);
+    }
+
+    @Cacheable(value = "activities", key = "#schedule.getId()", unless = "#result==null || #result.isEmpty()")
+    public List<Activity> getCachedActivities(Schedule schedule) {
+        return schedule.getActivityList();
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/ActivityManageService.java
@@ -54,6 +54,7 @@ public class ActivityManageService {
      * @param request
      * @return
      */
+    @CacheEvict(value = "ActivityInfoDtoList", key = "#scheduleId")
     public Activity createActivity(Long memberId, Long scheduleId, ActivityRequest.CreateActivityDto request) {
         Participant myParticipant = participantManageService.getParticipantByMemberAndSchedule(memberId, scheduleId);
         Activity activity = activityService.createActivity(ActivityConverter.toActivity(myParticipant.getSchedule(), request));

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
@@ -85,6 +85,7 @@ public class ActivityUseCase {
     @Transactional
     public void deleteActivity(Long memberId, Long activityId) {
         Activity target = activityManageService.getMyActivity(memberId, activityId);
-        activityManageService.removeActivity(target);
+        Long scheduleId = target.getSchedule().getId();
+        activityManageService.removeActivity(target, scheduleId);
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
@@ -2,6 +2,7 @@ package com.namo.spring.application.external.api.record.usecase;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +26,7 @@ public class ActivityUseCase {
     private final ActivityManageService activityManageService;
     private final ActivityParticipantManageService activityParticipantManageService;
 
+    @Cacheable(value = "activities", key = "#scheduleId", unless = "#result==null || #result.isEmpty()")
     @Transactional(readOnly = true)
     public List<ActivityResponse.ActivityInfoDto> getActivities(Long memberId, Long scheduleId) {
         Schedule schedule = participantManageService.getParticipantByMemberAndSchedule(memberId, scheduleId).getSchedule();

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
@@ -57,7 +57,8 @@ public class ActivityUseCase {
     @Transactional
     public void updateActivity(Long memberId, Long activityId, ActivityRequest.UpdateActivityDto request) {
         Activity target = activityManageService.getMyActivity(memberId, activityId);
-        activityManageService.updateActivity(target, request);
+        Long scheduleId = target.getSchedule().getId();
+        activityManageService.updateActivity(target, request, scheduleId);
     }
 
     @Transactional

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
@@ -26,13 +26,12 @@ public class ActivityUseCase {
     private final ActivityManageService activityManageService;
     private final ActivityParticipantManageService activityParticipantManageService;
 
+    @Cacheable(value = "ActivityInfoDtoList", key = "#scheduleId", cacheManager = "redisCacheManager", unless = "#result==null")
     @Transactional(readOnly = true)
-    public List<ActivityResponse.ActivityInfoDto> getActivities(Long memberId, Long scheduleId) {
+    public ActivityResponse.ActivityInfoDtoList getActivities(Long memberId, Long scheduleId) {
         Schedule schedule = participantManageService.getParticipantByMemberAndSchedule(memberId, scheduleId).getSchedule();
-        List<Activity> activities = activityManageService.getCachedActivities(schedule);
-        return activities.stream()
-                .map(ActivityResponseConverter::toActivityInfoDto)
-                .toList();
+        List<Activity> activities = schedule.getActivityList();
+        return ActivityResponseConverter.toActivityInfoDtoList(activities);
     }
 
     @Transactional(readOnly = true)

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/usecase/ActivityUseCase.java
@@ -26,12 +26,10 @@ public class ActivityUseCase {
     private final ActivityManageService activityManageService;
     private final ActivityParticipantManageService activityParticipantManageService;
 
-    @Cacheable(value = "activities", key = "#scheduleId", unless = "#result==null || #result.isEmpty()")
     @Transactional(readOnly = true)
     public List<ActivityResponse.ActivityInfoDto> getActivities(Long memberId, Long scheduleId) {
         Schedule schedule = participantManageService.getParticipantByMemberAndSchedule(memberId, scheduleId).getSchedule();
-        List<Activity> activities = schedule.getActivityList();
-
+        List<Activity> activities = activityManageService.getCachedActivities(schedule);
         return activities.stream()
                 .map(ActivityResponseConverter::toActivityInfoDto)
                 .toList();

--- a/storage/db-mysql-v2/build.gradle
+++ b/storage/db-mysql-v2/build.gradle
@@ -15,4 +15,6 @@ dependencies {
     // flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }

--- a/storage/db-redis/src/main/java/com/namo/spring/db/redis/config/RedisConfig.java
+++ b/storage/db-redis/src/main/java/com/namo/spring/db/redis/config/RedisConfig.java
@@ -63,18 +63,12 @@ public class RedisConfig {
 
 	@Bean
 	@DomainRedisCacheManager
-	public RedisCacheManager redisCacheManager(
-		@DomainRedisConnectionFactory RedisConnectionFactory cf
-	) {
+	public RedisCacheManager redisCacheManager(@DomainRedisConnectionFactory RedisConnectionFactory cf) {
 		RedisCacheConfiguration cacheConfiguration =
 			RedisCacheConfiguration.defaultCacheConfig()
-				.serializeKeysWith(
-					RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
-				)
-				.serializeValuesWith(
-					RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
-				)
-				.entryTtl(Duration.ofHours(1L));
+				.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+				.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+				.entryTtl(Duration.ofHours(3L));
 
 		return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
 			.cacheDefaults(cacheConfiguration)


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [X] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

 다수의 사용자에 의해 같은 화면이 자주 조회되는 '모임 활동 조회' API에 Redis를 활용한 Look-Aside 캐시 전략을 적용했습니다.

- "모임 활동 조회에" API 캐시 적용
  - 활동 수정시 캐시 무효화 적용
  - 활동 삭제시 캐시 무효화 적용
  
- List 역직렬화를 위해 Wrapper Class 생성하여 사용하도록 로직 변경

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 추가로 캐시가 적용될 API에 대해 의견 부탁드립니다.

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- Java 8의 날짜/시간 타입인 LocalDateTime을 캐시할 때 문제가 발생하여 jackson-datatype-jsr310 모듈을 사용하여 해결하였습니다.
- List를 그대로 캐싱하는경우 @Class 정보가 함께 붙어 캐시정보를 가져오는 과정에서 에러가 발생합니다. (Wrapper Class로 변경 필요)
- 캐싱 대상에 대해 기본생성자가 존재하지 않으면 에러가 발생합니다. 

### 고민 중인 사항



## 첨부 자료

- 개선 전
<img width="328" alt="image" src="https://github.com/user-attachments/assets/571910f8-6604-444e-95c4-6987fa610dd1">

- 개선 후
<img width="403" alt="image" src="https://github.com/user-attachments/assets/e576704a-1e2a-4367-b8d0-b992220bc395">

- 결과

**1. 평균 응답 시간 (Average)**

  - 캐싱 전: 33ms
  - 캐싱 후: 8ms
  - 캐싱 적용으로 평균 응답 시간이 약 75.76% 감소했습니다.

**2. 최소 응답 시간 (Min)**

  - 캐싱 전: 17ms
  - 캐싱 후: 4ms
  - 캐싱을 적용함으로써 최소 응답 시간이 76.47% 감소했습니다.

**3. 최대 응답 시간 (Max)**

  - 캐싱 전: 516ms
  - 캐싱 후: 34ms
  - 최대 응답 시간이 93.41% 감소하며 안정성이 크게 향상되었습니다.

## 관련 이슈

- close #413 
