### PR TITLE
[Feature/415] 친구 생일 조회 API 캐싱 적용

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/converter/GuestMeetingResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/converter/GuestMeetingResponseConverter.java
@@ -1,12 +1,6 @@
 package com.namo.spring.application.external.api.guest.converter;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import com.namo.spring.application.external.api.guest.dto.GuestMeetingResponse;
-import com.namo.spring.core.common.utils.DateUtil;
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 
 public class GuestMeetingResponseConverter {

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/service/GuestManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/guest/service/GuestManageService.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.namo.spring.application.external.global.config.properties.WebUrlConfig;
-import com.namo.spring.db.mysql.domains.schedule.service.ScheduleService;
 import org.springframework.stereotype.Service;
 
 import com.namo.spring.application.external.api.guest.dto.GuestParticipantRequest;
@@ -23,7 +22,7 @@ import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.exception.ParticipantException;
 import com.namo.spring.db.mysql.domains.schedule.service.ParticipantService;
 import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
-import com.namo.spring.db.mysql.domains.user.dto.AnonymousInviteCodeQuery;
+import com.namo.spring.db.mysql.domains.user.model.query.AnonymousInviteCodeQuery;
 import com.namo.spring.db.mysql.domains.user.entity.Anonymous;
 import com.namo.spring.db.mysql.domains.user.exception.AnonymousException;
 import com.namo.spring.db.mysql.domains.user.service.AnonymousService;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/PersonalScheduleController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/controller/PersonalScheduleController.java
@@ -11,7 +11,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -60,7 +59,7 @@ public class PersonalScheduleController implements PersonalScheduleApi {
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
             @AuthenticationPrincipal SecurityUserDetails member) {
         validatePeriod(startDate, endDate);
-        return ResponseDto.onSuccess(personalScheduleUsecase.getMonthlyFriendsBirthday(startDate, endDate, member));
+        return ResponseDto.onSuccess(personalScheduleUsecase.getMonthlyFriendsBirthday(startDate, endDate, member.getUserId()));
     }
 
     /**

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
@@ -1,8 +1,8 @@
 package com.namo.spring.application.external.api.schedule.converter;
 
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleResponse;
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleParticipantQuery;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleSummaryQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.type.Location;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/PersonalScheduleResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/PersonalScheduleResponseConverter.java
@@ -9,14 +9,14 @@ import java.util.stream.Collectors;
 
 import com.namo.spring.application.external.api.schedule.dto.PersonalScheduleResponse;
 import com.namo.spring.application.external.global.utils.ReminderTimeUtils;
-import com.namo.spring.core.common.utils.DateUtil;
 import com.namo.spring.db.mysql.domains.category.entity.Category;
 import com.namo.spring.db.mysql.domains.notification.dto.ScheduleNotificationQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.type.Location;
 import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
-import com.namo.spring.db.mysql.domains.user.dto.FriendBirthdayQuery;
+import com.namo.spring.db.mysql.domains.user.model.dto.FriendBirthdayListDto;
+import com.namo.spring.db.mysql.domains.user.model.query.FriendBirthdayQuery;
 
 public class PersonalScheduleResponseConverter {
     private PersonalScheduleResponseConverter() {
@@ -122,17 +122,17 @@ public class PersonalScheduleResponseConverter {
                 .build();
     }
 
-    public static List<PersonalScheduleResponse.GetMonthlyFriendBirthdayDto> toGetMonthlyFriendBirthdayDtos(List<FriendBirthdayQuery> friendBirthdays, LocalDate startDate, LocalDate endDate){
+    public static List<PersonalScheduleResponse.GetMonthlyFriendBirthdayDto> toGetMonthlyFriendBirthdayListDto(List<FriendBirthdayListDto.FriendBirthdayDto> friendBirthdays, LocalDate startDate, LocalDate endDate){
         return friendBirthdays.stream()
                 .map(friendBirthday -> toGetMonthlyFriendBirthdayDto(friendBirthday, startDate, endDate))
                 .collect(Collectors.toList());
     }
 
-    public static PersonalScheduleResponse.GetMonthlyFriendBirthdayDto toGetMonthlyFriendBirthdayDto(FriendBirthdayQuery friendBirthday, LocalDate startDate, LocalDate endDate){
+    public static PersonalScheduleResponse.GetMonthlyFriendBirthdayDto toGetMonthlyFriendBirthdayDto(FriendBirthdayListDto.FriendBirthdayDto friendBirthday, LocalDate startDate, LocalDate endDate){
         int year = friendBirthday.getBirthday().getMonthValue() == startDate.getMonthValue() ? startDate.getYear() : endDate.getYear();
         return PersonalScheduleResponse.GetMonthlyFriendBirthdayDto.builder()
                 .nickname(friendBirthday.getNickname())
-                .birthdayDate(friendBirthday.getBirthday().withYear(year).atStartOfDay())
+                .birthdayDate(friendBirthday.getBirthday().withYear(year))
                 .build();
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/PersonalScheduleResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/PersonalScheduleResponse.java
@@ -1,5 +1,6 @@
 package com.namo.spring.application.external.api.schedule.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class PersonalScheduleResponse {
     private PersonalScheduleResponse() {
@@ -92,7 +94,7 @@ public class PersonalScheduleResponse {
         @Schema(description = "알림 트리거, 정시 -> 'ST', 일-> 'D{1-59 까지의 정수}', 시-> 'H{1-36 까지의 정수}', 분-> 'M{1-7 까지의 정수}")
         private String trigger;
     }
-
+    
     @AllArgsConstructor
     @Getter
     @Builder
@@ -100,8 +102,8 @@ public class PersonalScheduleResponse {
     public static class GetMonthlyFriendBirthdayDto {
         @Schema(description = "친구 이름", example = "나몽")
         private String nickname;
-        @Schema(description = "친구의 생일(현재 년도 기준)", example = "2024-10-04 00:00:00")
-        private LocalDateTime birthdayDate;
+        @Schema(description = "친구의 생일(현재 년도 기준)", example = "2024-10-04")
+        private LocalDate birthdayDate;
     }
 
     @AllArgsConstructor

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/service/ScheduleManageService.java
@@ -9,14 +9,14 @@ import java.util.stream.Collectors;
 
 import com.namo.spring.application.external.api.category.service.CategoryManageService;
 import com.namo.spring.db.mysql.domains.category.entity.Category;
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleSummaryQuery;
 import org.springframework.stereotype.Service;
 
 import com.namo.spring.application.external.api.schedule.converter.LocationConverter;
 import com.namo.spring.application.external.api.schedule.dto.MeetingScheduleRequest;
 import com.namo.spring.application.external.api.schedule.dto.PersonalScheduleRequest;
 import com.namo.spring.core.common.code.status.ErrorStatus;
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleParticipantQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.schedule.exception.ScheduleException;
@@ -28,7 +28,6 @@ import com.namo.spring.db.mysql.domains.schedule.type.Period;
 import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 import com.namo.spring.db.mysql.domains.user.entity.User;
-import com.namo.spring.db.mysql.domains.user.service.FriendshipService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/usecase/MeetingScheduleUsecase.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleSummaryQuery;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +20,7 @@ import com.namo.spring.application.external.api.schedule.service.ParticipantMana
 import com.namo.spring.application.external.api.schedule.service.ScheduleManageService;
 import com.namo.spring.application.external.api.user.service.MemberManageService;
 import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleParticipantQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 import com.namo.spring.db.mysql.domains.user.entity.Member;

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -4,11 +4,10 @@ import com.namo.spring.application.external.api.user.converter.FriendshipConvert
 import com.namo.spring.application.external.global.utils.FriendshipValidator;
 import com.namo.spring.core.common.code.status.ErrorStatus;
 import com.namo.spring.db.mysql.domains.schedule.exception.ScheduleException;
-import com.namo.spring.db.mysql.domains.user.model.dto.FriendBirthdayListDto;
-import com.namo.spring.db.mysql.domains.user.model.query.FriendBirthdayQuery;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 import com.namo.spring.db.mysql.domains.user.exception.MemberException;
+import com.namo.spring.db.mysql.domains.user.model.dto.FriendBirthdayListDto;
 import com.namo.spring.db.mysql.domains.user.service.FriendshipService;
 import com.namo.spring.db.mysql.domains.user.type.FriendshipStatus;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +23,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -72,9 +70,15 @@ public class FriendManageService {
     /**
      * 친구 요청을 수락하는 메서드입니다.
      * !! 나에게 온 요청이 맞는지 검증합니다.
+     * 수락 시 내 친구 생일 조회 및
+     * 친구 사용자의 친구 생일 조회 데이터가 무효화 됩니다.
      * @param memberId 수락할 사람 ID
      * @param friendship 수락할 요청 건
      */
+    @Caching(evict = {
+            @CacheEvict(value = "friendsBirthdayDtoList", key = "#memberId"),
+            @CacheEvict(value = "friendsBirthdayDtoList", key = "#friendship.member.id")
+    })
     public void acceptRequest(Long memberId, Friendship friendship) {
         friendshipValidator.validateFriendshipToMember(friendship, memberId);
         friendship.accept();

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/service/FriendManageService.java
@@ -147,6 +147,10 @@ public class FriendManageService {
      * @param target
      * @param reversedTarget
      */
+    @Caching(evict = {
+            @CacheEvict(value = "friendsBirthdayDtoList", key = "#target.member.id"),
+            @CacheEvict(value = "friendsBirthdayDtoList", key = "#target.friend.id")
+    })
     public void deleteFriendShip(Friendship target, Friendship reversedTarget) {
         friendshipService.deleteAll(Arrays.asList(target, reversedTarget));
     }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/model/query/ScheduleParticipantQuery.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/model/query/ScheduleParticipantQuery.java
@@ -1,4 +1,4 @@
-package com.namo.spring.db.mysql.domains.schedule.dto;
+package com.namo.spring.db.mysql.domains.schedule.model.query;
 
 import com.namo.spring.db.mysql.domains.schedule.entity.Schedule;
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/model/query/ScheduleSummaryQuery.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/model/query/ScheduleSummaryQuery.java
@@ -1,4 +1,4 @@
-package com.namo.spring.db.mysql.domains.schedule.dto;
+package com.namo.spring.db.mysql.domains.schedule.model.query;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -4,21 +4,21 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleSummaryQuery;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.namo.spring.db.mysql.domains.category.entity.Category;
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleParticipantQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
     List<Participant> findAllByScheduleId(Long scheduleId);
 
-    @Query("SELECT new com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery(" +
+    @Query("SELECT new com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleSummaryQuery(" +
             "s.id, " +
             "p.customTitle, " +
             "s.period.startDate, " +
@@ -59,7 +59,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
             "WHERE p.id in :ids AND s.id = :scheduleId")
     List<Participant> findParticipantByIdAndScheduleId(List<Long> ids, Long scheduleId);
 
-    @Query("SELECT DISTINCT new com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery(" +
+    @Query("SELECT DISTINCT new com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleParticipantQuery(" +
             "p.id, m.palette.id, m.id, m.nickname, s, p.customTitle, p.customImage, p.category.isShared, m.birthdayVisible" +
             ") FROM Participant p " +
             "JOIN p.schedule s " +

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/service/ParticipantService.java
@@ -4,13 +4,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleSummaryQuery;
-import com.namo.spring.db.mysql.domains.schedule.type.ParticipantRole;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleSummaryQuery;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.namo.spring.core.common.annotation.DomainService;
-import com.namo.spring.db.mysql.domains.schedule.dto.ScheduleParticipantQuery;
+import com.namo.spring.db.mysql.domains.schedule.model.query.ScheduleParticipantQuery;
 import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.schedule.repository.ParticipantRepository;
 import com.namo.spring.db.mysql.domains.schedule.type.ScheduleType;

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/model/dto/FriendBirthdayListDto.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/model/dto/FriendBirthdayListDto.java
@@ -1,0 +1,50 @@
+package com.namo.spring.db.mysql.domains.user.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.namo.spring.db.mysql.domains.user.model.query.FriendBirthdayQuery;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FriendBirthdayListDto {
+    private List<FriendBirthdayDto> friendsBirthdayDtoList;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class FriendBirthdayDto {
+        private Long memberId;
+        private String nickname;
+        @JsonSerialize(using = LocalDateSerializer.class)
+        @JsonDeserialize(using = LocalDateDeserializer.class)
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        private LocalDate birthday;
+    }
+
+    public static FriendBirthdayListDto of(List<FriendBirthdayQuery> queryList) {
+        List<FriendBirthdayDto> friendsBirthdayDtoList = queryList.stream()
+                .map(query -> FriendBirthdayDto.builder()
+                        .memberId(query.getMemberId())
+                        .nickname(query.getNickname())
+                        .birthday(query.getBirthday())
+                        .build())
+                .toList();
+
+        return FriendBirthdayListDto.builder()
+                .friendsBirthdayDtoList(friendsBirthdayDtoList)
+                .build();
+    }
+}

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/model/query/AnonymousInviteCodeQuery.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/model/query/AnonymousInviteCodeQuery.java
@@ -1,7 +1,6 @@
-package com.namo.spring.db.mysql.domains.user.dto;
+package com.namo.spring.db.mysql.domains.user.model.query;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/model/query/FriendBirthdayQuery.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/model/query/FriendBirthdayQuery.java
@@ -1,4 +1,4 @@
-package com.namo.spring.db.mysql.domains.user.dto;
+package com.namo.spring.db.mysql.domains.user.model.query;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/AnonymousRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/AnonymousRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import com.namo.spring.db.mysql.domains.user.dto.AnonymousInviteCodeQuery;
+import com.namo.spring.db.mysql.domains.user.model.query.AnonymousInviteCodeQuery;
 import com.namo.spring.db.mysql.domains.user.entity.Anonymous;
 
 public interface AnonymousRepository extends JpaRepository<Anonymous, Long> {
@@ -17,6 +17,6 @@ public interface AnonymousRepository extends JpaRepository<Anonymous, Long> {
 
     Optional<Anonymous> findAnonymousByTagAndNickname(String tag, String nickname);
 
-    @Query("SELECT new com.namo.spring.db.mysql.domains.user.dto.AnonymousInviteCodeQuery(a.inviteCode) FROM Anonymous a")
+    @Query("SELECT new com.namo.spring.db.mysql.domains.user.model.query.AnonymousInviteCodeQuery(a.inviteCode) FROM Anonymous a")
     List<AnonymousInviteCodeQuery> findAllInviteCodes();
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/repository/FriendshipRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import com.namo.spring.db.mysql.domains.user.dto.FriendBirthdayQuery;
+import com.namo.spring.db.mysql.domains.user.model.query.FriendBirthdayQuery;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -32,7 +32,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
      * @param endDate
      * @return 친구 memberId, nickname, birthday
      */
-    @Query("SELECT new com.namo.spring.db.mysql.domains.user.dto.FriendBirthdayQuery(fr.id, fr.nickname, fr.birthday) " +
+    @Query("SELECT new com.namo.spring.db.mysql.domains.user.model.query.FriendBirthdayQuery(fr.id, fr.nickname, fr.birthday) " +
             "FROM Friendship f JOIN f.friend fr " +
             "WHERE f.member.id = :memberId " +
             "AND fr.birthdayVisible = true " +
@@ -49,6 +49,19 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
             Long memberId,
             LocalDate startDate,
             LocalDate endDate);
+
+
+    /**
+     * 모든 친구들의 생일을 조회합니다.
+     * @param memberId
+     * @return 친구 memberId, nickname, birthday
+     */
+    @Query("SELECT new com.namo.spring.db.mysql.domains.user.model.query.FriendBirthdayQuery(fr.id, fr.nickname, fr.birthday) " +
+            "FROM Friendship f JOIN f.friend fr " +
+            "WHERE f.member.id = :memberId " +
+            "AND fr.birthdayVisible = true " +
+            "AND f.status = 'ACCEPTED'")
+    List<FriendBirthdayQuery> findBirthdayVisibleFriends(Long memberId);
 
     Optional<Friendship> findByMemberIdAndFriendIdAndStatus(Long memberId, Long friendId, FriendshipStatus status);
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/AnonymousService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/AnonymousService.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.namo.spring.core.common.annotation.DomainService;
-import com.namo.spring.db.mysql.domains.user.dto.AnonymousInviteCodeQuery;
+import com.namo.spring.db.mysql.domains.user.model.query.AnonymousInviteCodeQuery;
 import com.namo.spring.db.mysql.domains.user.entity.Anonymous;
 import com.namo.spring.db.mysql.domains.user.repository.AnonymousRepository;
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -4,11 +4,12 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import com.namo.spring.db.mysql.domains.user.model.dto.FriendBirthdayListDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.namo.spring.core.common.annotation.DomainService;
-import com.namo.spring.db.mysql.domains.user.dto.FriendBirthdayQuery;
+import com.namo.spring.db.mysql.domains.user.model.query.FriendBirthdayQuery;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.repository.FriendshipRepository;
 import com.namo.spring.db.mysql.domains.user.type.FriendshipStatus;
@@ -79,8 +80,18 @@ public class FriendshipService {
      * @return 친구 memberId, nickname, birthday
      */
     @Transactional(readOnly = true)
-    public List<FriendBirthdayQuery> readBirthdayVisibleFriendsByPeriod(Long memberId, LocalDate startDate,
+    public FriendBirthdayListDto readBirthdayVisibleFriendsByPeriod(Long memberId, LocalDate startDate,
                                                                         LocalDate endDate){
-        return friendshipRepository.findBirthdayVisibleFriendIdsByPeriod(memberId, startDate, endDate);
+        return FriendBirthdayListDto.of(friendshipRepository.findBirthdayVisibleFriendIdsByPeriod(memberId, startDate, endDate));
+    }
+
+    /**
+     * 모든 친구들의 생일을 조회합니다.
+     * @param memberId
+     * @return 친구 memberId, nickname, birthday
+     */
+    @Transactional(readOnly = true)
+    public FriendBirthdayListDto readBirthdayVisibleFriendsByPeriod(Long memberId){
+        return FriendBirthdayListDto.of(friendshipRepository.findBirthdayVisibleFriends(memberId));
     }
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [x] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- ✏️ **친구 생일 조회 API 캐싱 적용**
  - 🗑️친구 수락 및 삭제 캐시 무효화

- ♻️ **캐싱 도입 후 친구 생일 조회 로직 수정**
  - 변경 전 : startDate, endDate를 인자로 받아 쿼리로 해당 기간의 생일자만 조회 
  - 변경 후 : 쿼리로 모든 친구 생일 조회 한 후, startDate, endDate 사이의 생일만 필터링
  - 추가적으로 List 역직렬화를 위해 service layer dto용 Wrapper Class 생성하여 사용하도록 로직 변경

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

**✔️ 캐싱 도입 전**
![image](https://github.com/user-attachments/assets/0e7bb6fa-0d26-49cc-94d3-21cd088aced1)


**🧪 캐싱 도입 V1 - startDate, endDate 사이의 친구 생일만 필터링하여 캐싱**
![image](https://github.com/user-attachments/assets/9a14e56e-f819-45e2-8b4b-cadb5484af83)

**✅ 캐싱 도입 V2 - 모든 친구 생일 조회하여 캐싱**
![image](https://github.com/user-attachments/assets/8f0020c0-af73-4d63-ae9e-188748a6c054)

- 지표 값 비교 결과 V2 채택
- 응답 시간: 평균 응답 시간 기존 버전에 비해 60% 감소
- 처리량(Throughput): 기존 버전에 비해 처리량이 149.5% 증가
- 데이터 전송 속도: 기존 버전에 비해 수신 속도 및 송신 속도 약 150% 증가

## 관련 이슈

- close #415
