### PR TITLE
[Feature/417] 프로필 설정 기능 구현 + hot fix

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/converter/MeetingScheduleResponseConverter.java
@@ -25,6 +25,7 @@ public class MeetingScheduleResponseConverter {
                 .meetingScheduleId(schedule.getMeetingScheduleId())
                 .title(schedule.getTitle())
                 .startDate(schedule.getStartDate())
+                .endDate(schedule.getEndDate())
                 .imageUrl(schedule.getImageUrl())
                 .participantCount(schedule.getParticipantCount())
                 .participantNicknames(schedule.getParticipantNicknames())

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/MeetingScheduleResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/schedule/dto/MeetingScheduleResponse.java
@@ -26,6 +26,8 @@ public class MeetingScheduleResponse {
         private String title;
         @Schema(description = "일정 시작일", example = "2024-10-04 00:00:00")
         private LocalDateTime startDate;
+        @Schema(description = "일정 종료일", example = "2024-10-05 00:00:00")
+        private LocalDateTime endDate;
         @Schema(description = "모임 일정 이미지  url")
         private String imageUrl;
         @Schema(description = "모임 일정 참여자 수", example = "9")

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/ProfileController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/ProfileController.java
@@ -2,9 +2,12 @@ package com.namo.spring.application.external.api.user.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.namo.spring.application.external.api.user.dto.ProfileRequest;
 import com.namo.spring.application.external.api.user.dto.ProfileResponse;
 import com.namo.spring.application.external.api.user.usecase.ProfileUseCase;
 import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
@@ -29,5 +32,15 @@ public class ProfileController {
             @AuthenticationPrincipal SecurityUserDetails member
     ){
         return ResponseDto.onSuccess(profileUseCase.getProfile(member.getUserId()));
+    }
+
+    @PatchMapping("")
+    @Operation(summary = "내 프로필 수정", description = "내 프로필 정보를 수정합니다.")
+    public ResponseDto<String> updateProfile(
+            @AuthenticationPrincipal SecurityUserDetails member,
+            @RequestBody ProfileRequest.UpdateProfileDto request
+    ){
+        profileUseCase.updateProfile(member.getUserId(), request);
+        return ResponseDto.onSuccess("내 정보 수정 완료");
     }
 }

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/ProfileController.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/controller/ProfileController.java
@@ -1,0 +1,33 @@
+package com.namo.spring.application.external.api.user.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.namo.spring.application.external.api.user.dto.ProfileResponse;
+import com.namo.spring.application.external.api.user.usecase.ProfileUseCase;
+import com.namo.spring.application.external.global.common.security.authentication.SecurityUserDetails;
+import com.namo.spring.core.common.response.ResponseDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "10. Profile", description = "내 프로필 관리 API")
+@RequestMapping("/api/v2/profile")
+public class ProfileController {
+
+    private final ProfileUseCase profileUseCase;
+
+    @GetMapping("")
+    @Operation(summary = "내 프로필 보기", description = "내 프로필 정보를 조회합니다.")
+    public ResponseDto<ProfileResponse.ProfileInfoDto> getProfileInfo(
+            @AuthenticationPrincipal SecurityUserDetails member
+    ){
+        return ResponseDto.onSuccess(profileUseCase.getProfile(member.getUserId()));
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/ProfileConverter.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/converter/ProfileConverter.java
@@ -1,0 +1,20 @@
+package com.namo.spring.application.external.api.user.converter;
+
+import com.namo.spring.application.external.api.user.dto.ProfileResponse;
+import com.namo.spring.db.mysql.domains.user.entity.Member;
+
+public class ProfileConverter {
+
+    public static ProfileResponse.ProfileInfoDto toProfileInfoDto(Member member){
+        return ProfileResponse.ProfileInfoDto.builder()
+                .nickname(member.getNickname())
+                .name(member.getName())
+                .isNameVisible(member.isNameVisible())
+                .isBirthdayVisible(member.isBirthdayVisible())
+                .birthdate(member.getBirthday())
+                .bio(member.getBio())
+                .profileImage(member.getProfileImage())
+                .favoriteColorId(member.getPalette().getId())
+                .build();
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/ProfileRequest.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/ProfileRequest.java
@@ -1,0 +1,30 @@
+package com.namo.spring.application.external.api.user.dto;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ProfileRequest {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateProfileDto{
+        @NotNull(message = "닉네임은 필수 값입니다.")
+        private String nickname;
+        @NotNull(message = "이름 공개 여부는 필수 값입니다.")
+        private boolean isNameVisible;
+        @NotNull(message = "생일은 필수 값입니다.")
+        private LocalDate birthday;
+        @NotNull(message = "생일 공개 여부는 필수 값입니다.")
+        private boolean isBirthdayVisible;
+        private String bio;
+        private String profileImage;
+        @NotNull(message = "선호 색상은 필수 값입니다.")
+        private Long favoriteColorId;
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/ProfileResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/dto/ProfileResponse.java
@@ -1,0 +1,22 @@
+package com.namo.spring.application.external.api.user.dto;
+
+import java.time.LocalDate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class ProfileResponse {
+
+    @Getter
+    @Builder
+    public static class ProfileInfoDto{
+        private String nickname;
+        private String name;
+        private boolean isNameVisible;
+        private LocalDate birthdate;
+        private boolean isBirthdayVisible;
+        private String bio;
+        private String profileImage;
+        private Long favoriteColorId;
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/ProfileUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/ProfileUseCase.java
@@ -1,0 +1,24 @@
+package com.namo.spring.application.external.api.user.usecase;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.namo.spring.application.external.api.user.converter.ProfileConverter;
+import com.namo.spring.application.external.api.user.dto.ProfileResponse;
+import com.namo.spring.application.external.api.user.service.MemberManageService;
+import com.namo.spring.db.mysql.domains.user.entity.Member;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileUseCase {
+
+    private MemberManageService memberManageService;
+
+    @Transactional(readOnly = true)
+    public ProfileResponse.ProfileInfoDto getProfile(Long memberId) {
+        Member member = memberManageService.getActiveMember(memberId);
+        return ProfileConverter.toProfileInfoDto(member);
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/ProfileUseCase.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/user/usecase/ProfileUseCase.java
@@ -4,8 +4,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.namo.spring.application.external.api.user.converter.ProfileConverter;
+import com.namo.spring.application.external.api.user.dto.ProfileRequest;
 import com.namo.spring.application.external.api.user.dto.ProfileResponse;
 import com.namo.spring.application.external.api.user.service.MemberManageService;
+import com.namo.spring.db.mysql.domains.category.entity.Palette;
+import com.namo.spring.db.mysql.domains.category.service.PaletteService;
 import com.namo.spring.db.mysql.domains.user.entity.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -14,11 +17,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProfileUseCase {
 
-    private MemberManageService memberManageService;
+    private final MemberManageService memberManageService;
+    private final PaletteService paletteService;
 
     @Transactional(readOnly = true)
     public ProfileResponse.ProfileInfoDto getProfile(Long memberId) {
         Member member = memberManageService.getActiveMember(memberId);
         return ProfileConverter.toProfileInfoDto(member);
+    }
+
+    @Transactional
+    public void updateProfile(Long memberId, ProfileRequest.UpdateProfileDto request) {
+        Member member = memberManageService.getActiveMember(memberId);
+        Palette palette = paletteService.getPalette(request.getFavoriteColorId());
+        member.updatePalette(palette);
+        member.updateProfile(request.getNickname(), request.isNameVisible(),request.getBirthday(),
+                request.isBirthdayVisible(), request.getBio(), request.getProfileImage());
+        memberManageService.saveMember(member);
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/model/query/ScheduleSummaryQuery.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/model/query/ScheduleSummaryQuery.java
@@ -13,6 +13,7 @@ public class ScheduleSummaryQuery {
     private Long meetingScheduleId;
     private String title;
     private LocalDateTime startDate;
+    private LocalDateTime endDate;
     private String imageUrl;
     private Integer participantCount;
     private String participantNicknames;

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/schedule/repository/ParticipantRepository.java
@@ -22,6 +22,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
             "s.id, " +
             "p.customTitle, " +
             "s.period.startDate, " +
+            "s.period.endDate, " +
             "p.customImage, " +
             "s.participantCount, " +
             "s.participantNicknames, " +

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Anonymous.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Anonymous.java
@@ -1,5 +1,7 @@
 package com.namo.spring.db.mysql.domains.user.entity;
 
+import static com.namo.spring.db.mysql.domains.user.utils.UserValidationUtils.*;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -14,6 +16,7 @@ import org.springframework.util.StringUtils;
 
 import com.namo.spring.db.mysql.common.model.BaseTimeEntity;
 import com.namo.spring.db.mysql.domains.user.type.Password;
+import com.namo.spring.db.mysql.domains.user.utils.UserValidationUtils;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -52,14 +55,10 @@ public class Anonymous extends BaseTimeEntity implements User {
     @Builder
     public Anonymous(String name, Boolean nameVisible, String tag,
             String nickname, String password, String inviteCode) {
-        if (!StringUtils.hasText(nickname))
-            throw new IllegalArgumentException("nickname은 null이거나 빈 문자열일 수 없습니다.");
-        if (!StringUtils.hasText(tag))
-            throw new IllegalArgumentException("tag는 null이거나 빈 문자열일 수 없습니다.");
         this.name = name;
         this.nameVisible = nameVisible;
-        this.tag = tag;
-        this.nickname = nickname;
+        this.tag = validateTag(tag);
+        this.nickname = validateNickname(nickname);
         this.password = Password.encrypt(password);
         this.inviteCode = inviteCode;
     }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
@@ -1,5 +1,7 @@
 package com.namo.spring.db.mysql.domains.user.entity;
 
+import static com.namo.spring.db.mysql.domains.user.utils.UserValidationUtils.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -35,6 +37,7 @@ import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.user.type.MemberRole;
 import com.namo.spring.db.mysql.domains.user.type.MemberStatus;
 import com.namo.spring.db.mysql.domains.user.type.SocialType;
+import com.namo.spring.db.mysql.domains.user.utils.UserValidationUtils;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -134,7 +137,7 @@ public class Member extends BaseTimeEntity implements User {
         this.tag = tag;
         this.email = email;
         this.authId = authId;
-        this.birthday = birthday;
+        this.birthday = validateBirthday(birthday);
         this.birthdayVisible = true;
         this.memberRole = MemberRole.USER;
         this.status = MemberStatus.PENDING;
@@ -172,16 +175,16 @@ public class Member extends BaseTimeEntity implements User {
         return !status.equals(MemberStatus.PENDING);
     }
 
-    public void signUpComplete(String name, String nickname, LocalDate birthday, String bio, String tag, Palette palette,
-            String profileImage) {
+    public void signUpComplete(String name, String nickname, LocalDate birthday, String bio,
+            String tag, Palette palette, String profileImage) {
         this.name = name;
-        this.nickname = nickname;
-        this.birthday = birthday;
-        this.bio = bio;
+        this.nickname = validateNickname(nickname);
+        this.birthday = validateBirthday(birthday);
+        this.bio = validateBio(bio);
         this.tag = tag;
         this.palette = palette;
         this.status = MemberStatus.ACTIVE;
-        this.profileImage = profileImage;
+        this.profileImage = validateProfileImage(profileImage);
         this.signUpAt = LocalDateTime.now();
     }
 
@@ -191,5 +194,15 @@ public class Member extends BaseTimeEntity implements User {
 
     public void updateNotificationEnabled(boolean notificationEnabled){
         this.notificationEnabled = notificationEnabled;
+    }
+
+    public void updateProfile(String nickname, boolean nameVisible, LocalDate birthday,
+            boolean birthdayVisible, String bio, String profileImage) {
+        this.nickname = validateNickname(nickname);
+        this.nameVisible = nameVisible;
+        this.birthday = validateBirthday(birthday);
+        this.birthdayVisible = birthdayVisible;
+        this.bio = validateBio(bio);
+        this.profileImage = validateProfileImage(profileImage);
     }
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
@@ -37,7 +37,6 @@ import com.namo.spring.db.mysql.domains.schedule.entity.Participant;
 import com.namo.spring.db.mysql.domains.user.type.MemberRole;
 import com.namo.spring.db.mysql.domains.user.type.MemberStatus;
 import com.namo.spring.db.mysql.domains.user.type.SocialType;
-import com.namo.spring.db.mysql.domains.user.utils.UserValidationUtils;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/utils/UserValidationUtils.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/utils/UserValidationUtils.java
@@ -24,6 +24,13 @@ public class UserValidationUtils {
         return nickname.trim();
     }
 
+    public static String validateTag(String tag){
+        if (!StringUtils.hasText(tag)) {
+            throw new IllegalArgumentException("tag는 null이거나 빈 문자열일 수 없습니다.");
+        }
+        return tag;
+    }
+
     public static LocalDate validateBirthday(LocalDate birthday) {
         if (birthday == null) {
             throw new IllegalArgumentException("생일은 null일 수 없습니다.");

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/utils/UserValidationUtils.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/utils/UserValidationUtils.java
@@ -1,0 +1,57 @@
+package com.namo.spring.db.mysql.domains.user.utils;
+
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+
+public class UserValidationUtils {
+
+    private static final int MAX_NICKNAME_LENGTH = 12;
+    private static final int MAX_BIO_LENGTH = 50;
+    private static final String DEFAULT_PROFILE_IMAGE = "https://static.namong.shop/resized/origin/user/profile/namo-default-profile.png";
+
+    private UserValidationUtils() {
+        throw new UnsupportedOperationException("Utility class should not be instantiated");
+    }
+
+    public static String validateNickname(String nickname) {
+        if (!StringUtils.hasText(nickname)) {
+            throw new IllegalArgumentException("닉네임은 null이거나 빈 문자열일 수 없습니다.");
+        }
+        if (nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new IllegalArgumentException(String.format("닉네임은 %d자 이내여야 합니다.", MAX_NICKNAME_LENGTH));
+        }
+        return nickname.trim();
+    }
+
+    public static LocalDate validateBirthday(LocalDate birthday) {
+        if (birthday == null) {
+            throw new IllegalArgumentException("생일은 null일 수 없습니다.");
+        }
+        if (birthday.isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException("생일은 미래 날짜일 수 없습니다.");
+        }
+        return birthday;
+    }
+
+    public static String validateBio(String bio) {
+        if (bio == null) {
+            return null; // 한 줄 소개는 선택적 필드로 허용
+        }
+        if (bio.length() > MAX_BIO_LENGTH) {
+            throw new IllegalArgumentException(String.format("한 줄 소개는 %d자 이내여야 합니다.", MAX_BIO_LENGTH));
+        }
+        return bio.trim();
+    }
+
+    public static String validateProfileImage(String profileImage) {
+        if (profileImage == null) {
+            return DEFAULT_PROFILE_IMAGE; // 기본 프로필 이미지
+        }
+        String regex = "^(http|https)://.*\\.(jpg|jpeg|png|gif)$";
+        if (!profileImage.matches(regex)) {
+            throw new IllegalArgumentException("프로필 이미지는 유효한 이미지 URL이어야 합니다. (jpg, jpeg, png, gif 확장자만 허용)");
+        }
+        return profileImage;
+    }
+}


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 내 프로필 조회 기능 구현
- 내 프로필 수정 기능 구현
- 유저 Validation 관련 Class 분리해 유저 값 검증
  - 회원, 비회원 검증 로직 리팩토링
  - 기본 프로필 이미지 자동 적용

- 모임일정 조회시 스케줄에 endDate 추가 return


### 고민 중인 사항

- update시 paramerter가 너무 많아 고민됩니다. db 모듈과 application사이의 dto를 하나 더 만들어서 update시 통일화를 시켜줄지, 아니면 지금과 같이 값들로 넘길지 고민 중입니다.
- 다른 도메인들 값들에 대한 검증로직도 분리후 새로운 요구사항 명세에 따른 검증 여부가 필요합니다.

## 첨부 자료

<img width="304" alt="image" src="https://github.com/user-attachments/assets/ae63aa73-4685-47ce-bde1-5610bace8103">


## 관련 이슈

- close #417 
