### PR TITLE
[Refactor/421] Redis 직렬화/역직렬화 리팩토링

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/ActivityResponse.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/dto/ActivityResponse.java
@@ -4,11 +4,6 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.AllArgsConstructor;
@@ -35,13 +30,7 @@ public class ActivityResponse {
         private Long activityId;
         private String activityTitle;
         private List<ActivityParticipantDto> activityParticipants;
-        @JsonSerialize(using = LocalDateTimeSerializer.class)
-        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-        @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm")
         private LocalDateTime activityStartDate;
-        @JsonSerialize(using = LocalDateTimeSerializer.class)
-        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-        @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm")
         private LocalDateTime activityEndDate;
         private ActivityLocationDto activityLocation;
         private BigDecimal totalAmount;

--- a/storage/db-mysql-v2/build.gradle
+++ b/storage/db-mysql-v2/build.gradle
@@ -16,5 +16,4 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
 
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/entity/Member.java
@@ -136,7 +136,7 @@ public class Member extends BaseTimeEntity implements User {
         this.tag = tag;
         this.email = email;
         this.authId = authId;
-        this.birthday = validateBirthday(birthday);
+        this.birthday = birthday;
         this.birthdayVisible = true;
         this.memberRole = MemberRole.USER;
         this.status = MemberStatus.PENDING;

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/model/dto/FriendBirthdayListDto.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/model/dto/FriendBirthdayListDto.java
@@ -1,10 +1,5 @@
 package com.namo.spring.db.mysql.domains.user.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.namo.spring.db.mysql.domains.user.model.query.FriendBirthdayQuery;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,9 +23,6 @@ public class FriendBirthdayListDto {
     public static class FriendBirthdayDto {
         private Long memberId;
         private String nickname;
-        @JsonSerialize(using = LocalDateSerializer.class)
-        @JsonDeserialize(using = LocalDateDeserializer.class)
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         private LocalDate birthday;
     }
 

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/user/service/FriendshipService.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.namo.spring.core.common.annotation.DomainService;
-import com.namo.spring.db.mysql.domains.user.model.query.FriendBirthdayQuery;
 import com.namo.spring.db.mysql.domains.user.entity.Friendship;
 import com.namo.spring.db.mysql.domains.user.repository.FriendshipRepository;
 import com.namo.spring.db.mysql.domains.user.type.FriendshipStatus;

--- a/storage/db-redis/build.gradle
+++ b/storage/db-redis/build.gradle
@@ -9,4 +9,7 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.19.7"
     testImplementation "org.testcontainers:mysql:1.19.7"
     testImplementation "com.redis.testcontainers:testcontainers-redis-junit:1.6.4"
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }

--- a/storage/db-redis/src/main/java/com/namo/spring/db/redis/config/RedisConfig.java
+++ b/storage/db-redis/src/main/java/com/namo/spring/db/redis/config/RedisConfig.java
@@ -96,5 +96,14 @@ public class RedisConfig {
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS); // redis를 활용할 객체들에 날짜 정보가 TimeStamp 형식으로 적용되어있을 경우 그대로 RedisTemplate을 사용하면 에러가 발생하므로 그것에 대비하기 위한 설정값
     }
-    
+
+    @Bean
+    public ObjectMapper objectMapper(){
+        return new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS);
+    }
 }

--- a/storage/db-redis/src/main/java/com/namo/spring/db/redis/config/RedisConfig.java
+++ b/storage/db-redis/src/main/java/com/namo/spring/db/redis/config/RedisConfig.java
@@ -19,6 +19,12 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.namo.spring.db.redis.common.annotation.DomainRedisCacheManager;
 import com.namo.spring.db.redis.common.annotation.DomainRedisConnectionFactory;
 import com.namo.spring.db.redis.common.annotation.DomainRedisTemplate;
@@ -55,9 +61,8 @@ public class RedisConfig {
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
-
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(customObjectMapper()));
 		return redisTemplate;
 	}
 
@@ -67,11 +72,29 @@ public class RedisConfig {
 		RedisCacheConfiguration cacheConfiguration =
 			RedisCacheConfiguration.defaultCacheConfig()
 				.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-				.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+				.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(customObjectMapper())))
 				.entryTtl(Duration.ofHours(3L));
 
 		return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
 			.cacheDefaults(cacheConfiguration)
 			.build();
 	}
+
+
+    @Bean
+    public ObjectMapper customObjectMapper(){
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfSubType(Object.class)
+                .build();
+
+        return new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false) // 혹시라도 의도치 않거나 알 수 없는 정보가 들어와 시리얼라이즈를 할 수 없게 될 경우를 대비한 설정값
+                .registerModule(new JavaTimeModule())
+                .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL)
+                .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS); // redis를 활용할 객체들에 날짜 정보가 TimeStamp 형식으로 적용되어있을 경우 그대로 RedisTemplate을 사용하면 에러가 발생하므로 그것에 대비하기 위한 설정값
+    }
+    
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [X] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 기존 개별 값들에 대해 각각 직렬화/역직렬화를 지정해주어야 했던 로직을 개선했습니다.
  -  CustomObjectMapper를 만들고 bean등록을 통해 Redis 직렬화/역직렬화에 사용
  - 이때 Class 정보가 포함되기 때문에 기본 ObjectMapper 추가 생성
  - .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) 값을 통해 format 통일

  결과 : 기존 값들의 직렬화/역직렬화 중복 코드 삭제

++ hotfix : member 생성시 생일 검증 로직이 해제되었습니다. -> 최초 기본생성시 생일 없음.


## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) 를 통해 LocalDate관련 값들이 List로 반환되는 것을 TIMESTAMPS format으로 지정가능합니다.
- ObjectMapper를 bean으로 만들어 등록할 경우 redis를 제외한 모든 경우에 해당 mapper 설정이 적용되므로 기본 mapper가 필요합니다.
- 공용으로 Object를 받아 처리할 경우 다형성(Polymorphic) 타입의 직렬화와 역직렬화를 안전하게 처리하기 위한 타입 검증기가 필요합니다. (PolymorphicTypeValidator)

### 고민 중인 사항

- RedisConfig에 대해 더 공부하고 깔끔하게 다듬을 필요가 있습니다.

## 첨부 자료

- 트러블 슈팅 기록입니다.
- https://h-castle.tistory.com/entry/Redis-%EB%A0%88%EB%94%94%EC%8A%A4%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-Spring-boot-%EC%BA%90%EC%8B%B1-%EC%A0%81%EC%9A%A9-%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0-%ED%8A%B8%EB%9F%AC%EB%B8%94-%EC%8A%88%ED%8C%85

## 관련 이슈

- close #421 
