### PR TITLE
[Feature/423]원본 -> 리사이징 이미지 변환 기능 구현

### DIFF
--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/scheduler/ImageResizingScheduler.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/scheduler/ImageResizingScheduler.java
@@ -1,0 +1,52 @@
+package com.namo.spring.application.external.api.image.scheduler;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.namo.spring.application.external.api.image.service.ImageCacheService;
+import com.namo.spring.application.external.api.image.util.ImageKeyParser;
+import com.namo.spring.db.redis.util.RedisUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ImageResizingScheduler {
+
+    private static final Duration PROCESSING_DELAY = Duration.ofSeconds(25);
+    private static final String IMAGE_KEY_ZSET = "imageKeys";
+
+    private final ImageCacheService imageCacheService;
+    private final RedisUtil redisUtil;
+
+    /**
+     * 원본 이미지 -> 리사이징 URL 변경 스케줄러
+     * ** 원본 이미지 등록 25초 이후 리사이징 된 이미지로 변경합니다. **
+     */
+    @Scheduled(fixedRate = 20_000)
+    @Transactional
+    public void processResizedImages() {
+        Instant now = Instant.now();
+        long cutoffTime = now.minus(PROCESSING_DELAY).toEpochMilli();
+        Set<String> redisKeys = redisUtil.zRangeByScore(IMAGE_KEY_ZSET, 0, cutoffTime);
+
+        redisKeys.forEach(redisKey -> {
+            try {
+                ImageKeyParser.ParsedKey parsedKey = ImageKeyParser.parse(redisKey);
+                imageCacheService.convertToResizedImage(redisKey, parsedKey);
+                // 캐시 값 삭제
+                redisUtil.zRem(IMAGE_KEY_ZSET, redisKey);
+                redisUtil.delete(redisKey);
+            } catch (Exception e) {
+                log.error("원본 >>> 리사이징 이미지 변환 스케줄러 실패 : {}", redisKey, e);
+            }
+        });
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/service/ImageCacheService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/service/ImageCacheService.java
@@ -1,0 +1,80 @@
+package com.namo.spring.application.external.api.image.service;
+
+import org.springframework.stereotype.Component;
+
+import com.namo.spring.application.external.api.image.util.ImageKeyParser;
+import com.namo.spring.application.external.api.record.serivce.image.ActivityImageManageService;
+import com.namo.spring.application.external.api.record.serivce.image.DiaryImageManageService;
+import com.namo.spring.core.infra.common.constant.FilePath;
+import com.namo.spring.db.redis.util.RedisUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageCacheService {
+
+    private final ActivityImageManageService activityImageManageService;
+    private final DiaryImageManageService diaryImageManageService;
+    private final RedisUtil redisUtil;
+
+    public void convertToResizedImage(String redisKey, ImageKeyParser.ParsedKey parsedKey) {
+        try {
+            String originalUrl = redisUtil.get(redisKey);
+            if (originalUrl != null) {
+                String resizedUrl = convertResizedUrl(parsedKey.getEntityType(), originalUrl);
+                updateImageUrl(parsedKey.getEntityType(), parsedKey.getImageId(), resizedUrl);
+                log.info("이미지 주소 변환 성공 : Redis Key = {}, Resized URL = {}", redisKey, resizedUrl);
+            }
+        } catch (Exception e) {
+            log.error("이미지 주소 변환에 실패했습니다 : Redis Key = {}, Error = {}", redisKey, e.getMessage());
+        }
+    }
+
+    /**
+     * 각 이미지 엔티티를 찾아 URL 업데이트를 매니저에게 위임하여 실행합니다.
+     */
+    public void updateImageUrl(String entityType, Long imageId, String resizedUrl) {
+        switch (entityType) {
+            case "activity":
+                activityImageManageService.updateImageUrl(imageId, resizedUrl);
+                break;
+            case "diary":
+                diaryImageManageService.updateImageUrl(imageId, resizedUrl);
+                break;
+            default:
+                throw new IllegalArgumentException("지원되지 않는 이미지 엔티티 타입입니다 : " + entityType);
+        }
+    }
+
+    /**
+     * 원본 이미지를 리사이징 주소로 변환하여 반환하는 메서드입니다.
+     * @param entityType 이미지 엔티티
+     * @param originalUrl 원본 이미지 URL
+     * @return
+     */
+    public String convertResizedUrl(String entityType, String originalUrl) {
+        FilePath originalPath = findOriginalFilePath(entityType);
+        FilePath resizedPath = findResizedFilePath(entityType);
+
+        return originalUrl.replace(originalPath.getPath(), resizedPath.getPath());
+    }
+
+    private FilePath findOriginalFilePath(String entityType) {
+        return switch (entityType) {
+            case "activity" -> FilePath.ACTIVITY_IMG;
+            case "diary" -> FilePath.DIARY_IMG;
+            default -> throw new IllegalArgumentException("지원되지 않는 이미지 엔티티 타입입니다 : " + entityType);
+        };
+    }
+
+    private FilePath findResizedFilePath(String entityType) {
+        return switch (entityType) {
+            case "activity" -> FilePath.RESIZED_ACTIVITY_IMG;
+            case "diary" -> FilePath.RESIZED_DIARY_IMG;
+            default -> throw new IllegalArgumentException("지원되지 않는 이미지 엔티티 타입입니다 : " + entityType);
+        };
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/util/ImageKeyParser.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/image/util/ImageKeyParser.java
@@ -1,0 +1,49 @@
+package com.namo.spring.application.external.api.image.util;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Redis Image Resizing에 사용되는 Parser 값입니다.
+ * !! 상수 변경에 유의해 주세요. !!
+ */
+public class ImageKeyParser {
+
+    private static final int EXPECTED_PART_COUNT = 5;
+    private static final int ENTITY_TYPE_INDEX = 0;
+    private static final int IMAGE_ID_INDEX = 2;
+    private static final int TIMESTAMP_INDEX = 4;
+    private static final String IMAGE_ID_MARKER = "imageId";
+    private static final String TIMESTAMP_MARKER = "Timestamp";
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class ParsedKey {
+        private final String entityType;
+        private final Long imageId;
+        private final Long timestamp;
+    }
+
+    public static ParsedKey parse(String redisKey) {
+        String[] parts = redisKey.split(":");
+
+        validateKeyFormat(parts, redisKey);
+        try {
+            String entityType = parts[ENTITY_TYPE_INDEX];
+            Long imageId = Long.parseLong(parts[IMAGE_ID_INDEX]);
+            Long timestamp = Long.parseLong(parts[TIMESTAMP_INDEX]);
+
+            return new ParsedKey(entityType, imageId, timestamp);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to parse Redis key: " + redisKey, e);
+        }
+    }
+
+    private static void validateKeyFormat(String[] parts, String originalKey) {
+        if (parts.length != EXPECTED_PART_COUNT
+                || !parts[1].equals(IMAGE_ID_MARKER)
+                || !parts[3].equals(TIMESTAMP_MARKER)) {
+            throw new IllegalArgumentException("Invalid Redis key format: " + originalKey);
+        }
+    }
+}

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/image/AbstractImageManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/image/AbstractImageManageService.java
@@ -32,6 +32,7 @@ public abstract class AbstractImageManageService<T, R> implements ImageManageSer
             long timestamp = System.currentTimeMillis();
             String redisKey = generateImageRedisKey(entity, imageId, timestamp);
             redisUtil.saveWithTTL(redisKey, url, 100);
+            redisUtil.zAdd("imageKeys", redisKey, timestamp);
         });
     }
 

--- a/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/image/AbstractImageManageService.java
+++ b/application/external-api-v2/src/main/java/com/namo/spring/application/external/api/record/serivce/image/AbstractImageManageService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.namo.spring.core.infra.common.aws.s3.FileUtils;
 import com.namo.spring.core.infra.common.constant.FilePath;
+import com.namo.spring.db.redis.util.RedisUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,11 +17,34 @@ import lombok.extern.slf4j.Slf4j;
 public abstract class AbstractImageManageService<T, R> implements ImageManageService<T, R> {
 
     protected final FileUtils fileUtils;
+    protected final RedisUtil redisUtil;
 
     protected abstract void deleteAllImages(T entity);
-    protected abstract void createImage(T entity, String imageUrl);
+    protected abstract Long createImage(T entity, String imageUrl);
     protected abstract FilePath getOriginalFilePath();
     protected abstract String getImageUrl(Long imageId);
+
+
+    @Override
+    public void createImages(T entity, List<String> imageUrls) {
+        imageUrls.forEach(url -> {
+            Long imageId = createImage(entity, url);
+            long timestamp = System.currentTimeMillis();
+            String redisKey = generateImageRedisKey(entity, imageId, timestamp);
+            redisUtil.saveWithTTL(redisKey, url, 100);
+        });
+    }
+
+    /**
+     * Redis Key 생성 규칙 (예: "activity:imageId:{id}:Timestamp:{timestamp}")
+     * @param image 이미지 객체
+     * @param imageId 해당 ID
+     * @return
+     */
+    protected String generateImageRedisKey(T image, Long imageId, Long timestamp) {
+        return String.format("%s:imageId:%d:Timestamp:%d",
+                image.getClass().getSimpleName().toLowerCase(), imageId, timestamp);
+    }
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -36,10 +60,5 @@ public abstract class AbstractImageManageService<T, R> implements ImageManageSer
         } else {
             log.info("이미지 ID {} 가 존재하지 않습니다.", imageId);
         }
-    }
-
-    @Override
-    public void createImages(T entity, List<String> imageUrls) {
-        imageUrls.forEach(url -> createImage(entity, url));
     }
 }

--- a/core/core-infra/src/main/java/com/namo/spring/core/infra/config/AwsS3Config.java
+++ b/core/core-infra/src/main/java/com/namo/spring/core/infra/config/AwsS3Config.java
@@ -1,5 +1,7 @@
 package com.namo.spring.core.infra.config;
 
+import java.security.PublicKey;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,17 +21,21 @@ public class AwsS3Config {
     private final String region;
     @Getter
     private final String bucketName;
+    @Getter
+    private final String cdnPath;
 
     public AwsS3Config(
             @Value("${cloud.aws.credentials.access-key}") String accessKey,
             @Value("${cloud.aws.credentials.secret-key}") String secretKey,
             @Value("${cloud.aws.region.static}") String region,
-            @Value("${cloud.aws.s3.bucket}") String bucketName
+            @Value("${cloud.aws.s3.bucket}") String bucketName,
+            @Value("${cloud.aws.cloudfront}") String cdnName
     ) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.region = region;
         this.bucketName = bucketName;
+        this.cdnPath = cdnName;
     }
 
     @Bean
@@ -43,6 +49,10 @@ public class AwsS3Config {
                 .withRegion(region)
                 .withCredentials(new AWSStaticCredentialsProvider(awsS3Credentials()))
                 .build();
+    }
+
+    public String getS3Domain(){
+        return String.format("%s.s3.%s.amazonaws.com", bucketName, region);
     }
 }
 

--- a/core/core-infra/src/main/resources/aws.yml
+++ b/core/core-infra/src/main/resources/aws.yml
@@ -16,6 +16,7 @@ cloud:
       instanceProfile: true
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}
+    cloudfront: ${CDN_PATH}
 
 server:
   domain:

--- a/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/record/service/DiaryImageService.java
+++ b/storage/db-mysql-v2/src/main/java/com/namo/spring/db/mysql/domains/record/service/DiaryImageService.java
@@ -34,4 +34,8 @@ public class DiaryImageService {
     public void deleteAll(Diary diary) {
         diaryImageRepository.deleteAllByDiary(diary);
     }
+
+    public void save(DiaryImage diaryImage){
+        diaryImageRepository.save(diaryImage);
+    }
 }

--- a/storage/db-redis/src/main/java/com/namo/spring/db/redis/util/RedisUtil.java
+++ b/storage/db-redis/src/main/java/com/namo/spring/db/redis/util/RedisUtil.java
@@ -1,0 +1,53 @@
+package com.namo.spring.db.redis.util;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveWithTTL(String key, String value, long ttlInSeconds) {
+        try {
+            redisTemplate.opsForValue().set(key, value, ttlInSeconds, TimeUnit.SECONDS);
+            log.info("Redis에 저장 완료: key={}, value={}, TTL={}초", key, value, ttlInSeconds);
+        } catch (Exception e) {
+            log.error("Redis 저장 실패: key={}, value={}, 이유={}", key, value, e.getMessage());
+        }
+    }
+
+    public String get(String key) {
+        try {
+            return redisTemplate.opsForValue().get(key);
+        } catch (Exception e) {
+            log.error("Redis에서 key={} 조회 실패: 이유={}", key, e.getMessage());
+            return null;
+        }
+    }
+
+    public List<String> getKeys(String pattern) {
+        Set<String> keys = redisTemplate.keys(pattern);
+        return keys != null ? keys.stream().toList() : List.of();
+    }
+
+    public void delete(String key) {
+        try {
+            redisTemplate.delete(key);
+            log.info("Redis에서 key={} 삭제 완료", key);
+        } catch (Exception e) {
+            log.error("Redis에서 key={} 삭제 실패: 이유={}", key, e.getMessage());
+        }
+    }
+    
+
+}

--- a/storage/db-redis/src/main/java/com/namo/spring/db/redis/util/RedisUtil.java
+++ b/storage/db-redis/src/main/java/com/namo/spring/db/redis/util/RedisUtil.java
@@ -48,6 +48,18 @@ public class RedisUtil {
             log.error("Redis에서 key={} 삭제 실패: 이유={}", key, e.getMessage());
         }
     }
-    
+
+    // Redis의 Sorted Set 데이터 구조를 사용 기능
+    public void zAdd(String key, String value, double score) {
+        redisTemplate.opsForZSet().add(key, value, score);
+    }
+
+    public Set<String> zRangeByScore(String key, double min, double max) {
+        return redisTemplate.opsForZSet().rangeByScore(key, min, max);
+    }
+
+    public void zRem(String key, String value) {
+        redisTemplate.opsForZSet().remove(key, value);
+    }
 
 }


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [X] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- 활동, 일기 이미지(기록 이미지) 업로드시 Redis에 캐싱됩니다.
- 스케줄러에 의해 업로드 25초 이후 이미지에 대해 리사이징 이미지 URL로 변경됩니다.
- s3 도메인으로 온경우 CDN 주소로 변환이 추가되었습니다.
  - !! 로컬 환경변수 추가가 필요합니다.

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- Redis Sorted Set을 활용해 매번 저장된 Key Value를 꺼내 TImeStamp를 기준으로 정렬 후 반환하지 않아도 됩니다.
  - Redis에서 제공해주는 자료구조 중 하나인 Sorted Set(ZSET)을 활용한다면 Set의 특성과 저장된 value의 순서를 관리해줍니다.
  - ZRANGEBYSCORE을 통해 원하는 TIMESTAMP의 값들만 조회할 수 있습니다.

### 고민 중인 사항

- 이미지 엔티티에 대해 캐시 쓰기 전략을 Write Back(Write Behind) 패턴으로 변경하면  1이미지 생성 2이미지 URL 변경인 총 두번의 DB 요청을 리사이징 이후에 DB에 한번만 써 DB 부하를 개선할 수 있을 것 같습니다.
  - 하지만 캐시 오류 발생시 데이터 영구 손실의 문제와 조회시 로직 수정이 좀 있어 아직 적용해 보지 않았습니다.

## 첨부 자료

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/c84e36d8-2749-445b-b81a-a15bbd4332d2">


## 관련 이슈

- close #423
